### PR TITLE
Matrix square root for a not-perfectly PSD matrix

### DIFF
--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -60,6 +60,21 @@ class ExtendedBackend:
         e = self.sqrt(e)
         return v @ self.diagflat(e) @ self.adjoint(v)
 
+    def sqrtmhpos(self: Any, a: Tensor) -> Tensor:
+        """
+        Return the sqrtm of a known-to-be PSD Hermitian matrix ``a``.
+
+        :param a: tensor in matrix form
+        :type a: Tensor
+        :return: sqrtm of ``a`` after setting the negative eigenvalues (if they exist) to zero
+        :rtype: Tensor
+        """
+        # maybe friendly for AD and also cosidering that several backend has no support for native sqrtm
+        e, v = self.eigh(a)
+        e = self.relu(e)
+        e = self.sqrt(e)
+        return v @ self.diagflat(e) @ self.adjoint(v)
+
     def eigvalsh(self: Any, a: Tensor) -> Tensor:
         """
         Get the eigenvalues of matrix ``a``.


### PR DESCRIPTION
This method zeros out any negative eigenvalues before taking the matrix square root. This ensures that the matrix square root of a known-to-be PSD matrix continues to have real eigenvalues. This is useful sometimes in cases where one wants something like $\sqrt{A^\dagger A}$ but $A^\dagger A$ is imperfectly computed and has numerically small negative eigenvalues.