### PR TITLE
Fix JAX eigh

### DIFF
--- a/tensorcircuit/backends/jax_ops.py
+++ b/tensorcircuit/backends/jax_ops.py
@@ -151,11 +151,16 @@ adaware_qr_jit = jax.jit(adaware_qr)
 
 @jax.custom_vjp
 def adaware_eigh(A: Array) -> Array:
-    return jnp.linalg.eigh(A)
+    result = jnp.linalg.eigh(A)
+    e = result.eigenvalues
+    v = result.eigenvectors
+    return e, v
 
 
 def jaxeigh_fwd(A: Array) -> Array:
-    e, v = jnp.linalg.eigh(A)
+    result = jnp.linalg.eigh(A)
+    e = result.eigenvalues
+    v = result.eigenvectors
     return (e, v), (A, e, v)
 
 

--- a/tensorcircuit/backends/jax_ops.py
+++ b/tensorcircuit/backends/jax_ops.py
@@ -151,16 +151,12 @@ adaware_qr_jit = jax.jit(adaware_qr)
 
 @jax.custom_vjp
 def adaware_eigh(A: Array) -> Array:
-    result = jnp.linalg.eigh(A)
-    e = result.eigenvalues
-    v = result.eigenvectors
+    e, v = jnp.linalg.eigh(A)
     return e, v
 
 
 def jaxeigh_fwd(A: Array) -> Array:
-    result = jnp.linalg.eigh(A)
-    e = result.eigenvalues
-    v = result.eigenvectors
+    e, v = jnp.linalg.eigh(A)
     return (e, v), (A, e, v)
 
 


### PR DESCRIPTION
This is a bug coming from a commit on JAX, namely [012c5bd](https://github.com/jax-ml/jax/commit/012c5bd4398b6658b97e17c514f6051b2fef994d). The eigenvalues and eigenvectors are wrapped in a container object that needs to be unpacked. Otherwise, it causes an error down the line, like the following:
```
Custom VJP fwd rule jaxeigh_fwd for function adaware_eigh must produce a pair (list or tuple of length two) where the first element represents the primal output (equal to the output of the custom_vjp-decorated function adaware_eigh) and the second element represents residuals (i.e. values stored from the forward pass for use on the backward pass), but instead the fwd rule output's first element had container/pytree structure:
(float32[321, complex64[32, 32])
while the custom_vjp-decorated function adaware_eigh had output container/pytree structure:
EighResult (eigenvalues=float32[32], eigenvectors=complex64[32,32]) .
```