### PR TITLE
Backends

### DIFF
--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -349,11 +349,11 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
     def mod(self, x: Tensor, y: Tensor) -> Tensor:
         return jnp.mod(x, y)
 
-    def floor(self, x: Tensor) -> Tensor:
-        return jnp.floor(x)
+    def floor(self, a: Tensor) -> Tensor:
+        return jnp.floor(a)
 
-    def clip(self, x: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
-        return jnp.clip(x, a_min, a_max)
+    def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return jnp.clip(a, a_min, a_max)
 
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return jnp.right_shift(x, y)

--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -352,8 +352,8 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
     def floor(self, x: Tensor) -> Tensor:
         return jnp.floor(x)
 
-    def clip(self, x: Tensor, lower: Tensor, upper: Tensor) -> Tensor:
-        return jnp.clip(x, lower, upper)
+    def clip(self, x: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return jnp.clip(x, a_min, a_max)
 
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return jnp.right_shift(x, y)

--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -349,6 +349,12 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
     def mod(self, x: Tensor, y: Tensor) -> Tensor:
         return jnp.mod(x, y)
 
+    def floor(self, x: Tensor) -> Tensor:
+        return jnp.floor(x)
+
+    def clip(self, x: Tensor, lower: Tensor, upper: Tensor) -> Tensor:
+        return jnp.clip(x, lower, upper)
+
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return jnp.right_shift(x, y)
 

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -250,6 +250,12 @@ class NumpyBackend(numpy_backend.NumPyBackend, ExtendedBackend):  # type: ignore
     def mod(self, x: Tensor, y: Tensor) -> Tensor:
         return np.mod(x, y)
 
+    def floor(self, x: Tensor) -> Tensor:
+        return np.floor(x)
+
+    def clip(self, x: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return np.clip(x, a_min, a_max)
+
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return np.right_shift(x, y)
 

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -253,8 +253,8 @@ class NumpyBackend(numpy_backend.NumPyBackend, ExtendedBackend):  # type: ignore
     def floor(self, x: Tensor) -> Tensor:
         return np.floor(x)
 
-    def clip(self, x: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
-        return np.clip(x, a_min, a_max)
+    def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return np.clip(a, a_min, a_max)
 
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return np.right_shift(x, y)

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -250,8 +250,8 @@ class NumpyBackend(numpy_backend.NumPyBackend, ExtendedBackend):  # type: ignore
     def mod(self, x: Tensor, y: Tensor) -> Tensor:
         return np.mod(x, y)
 
-    def floor(self, x: Tensor) -> Tensor:
-        return np.floor(x)
+    def floor(self, a: Tensor) -> Tensor:
+        return np.floor(a)
 
     def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
         return np.clip(a, a_min, a_max)

--- a/tensorcircuit/backends/pytorch_backend.py
+++ b/tensorcircuit/backends/pytorch_backend.py
@@ -429,6 +429,12 @@ class PyTorchBackend(pytorch_backend.PyTorchBackend, ExtendedBackend):  # type: 
     def mod(self, x: Tensor, y: Tensor) -> Tensor:
         return torchlib.fmod(x, y)
 
+    def floor(self, x: Tensor) -> Tensor:
+        return torchlib.floor(x)
+
+    def clip(self, x: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return torchlib.clamp(x, a_min, a_max)
+
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return torchlib.bitwise_right_shift(x, y)
 

--- a/tensorcircuit/backends/pytorch_backend.py
+++ b/tensorcircuit/backends/pytorch_backend.py
@@ -432,8 +432,8 @@ class PyTorchBackend(pytorch_backend.PyTorchBackend, ExtendedBackend):  # type: 
     def floor(self, x: Tensor) -> Tensor:
         return torchlib.floor(x)
 
-    def clip(self, x: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
-        return torchlib.clamp(x, a_min, a_max)
+    def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return torchlib.clamp(a, a_min, a_max)
 
     def right_shift(self, x: Tensor, y: Tensor) -> Tensor:
         return torchlib.bitwise_right_shift(x, y)

--- a/tensorcircuit/backends/pytorch_backend.py
+++ b/tensorcircuit/backends/pytorch_backend.py
@@ -429,8 +429,8 @@ class PyTorchBackend(pytorch_backend.PyTorchBackend, ExtendedBackend):  # type: 
     def mod(self, x: Tensor, y: Tensor) -> Tensor:
         return torchlib.fmod(x, y)
 
-    def floor(self, x: Tensor) -> Tensor:
-        return torchlib.floor(x)
+    def floor(self, a: Tensor) -> Tensor:
+        return torchlib.floor(a)
 
     def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
         return torchlib.clamp(a, a_min, a_max)

--- a/tensorcircuit/backends/tensorflow_backend.py
+++ b/tensorcircuit/backends/tensorflow_backend.py
@@ -573,6 +573,22 @@ class TensorFlowBackend(tensorflow_backend.TensorFlowBackend, ExtendedBackend): 
     def stack(self, a: Sequence[Tensor], axis: int = 0) -> Tensor:
         return tf.stack(a, axis=axis)
 
+    def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
+        return tf.clip_by_value(a, a_min, a_max)
+
+    def floor(self, x: Tensor) -> Tensor:
+        dtype_str = x.dtype.name if hasattr(x.dtype, "name") else str(x.dtype)
+        if x.dtype.is_floating:
+            return tf.math.floor(x)
+        elif x.dtype.is_integer:
+            return x
+        elif x.dtype.is_complex:
+            raise TypeError(
+                f"tf.math.floor does not support complex dtype ({dtype_str})"
+            )
+        else:
+            raise TypeError(f"Unsupported dtype for floor: {dtype_str}")
+
     def concat(self, a: Sequence[Tensor], axis: int = 0) -> Tensor:
         return tf.concat(a, axis=axis)
 

--- a/tensorcircuit/backends/tensorflow_backend.py
+++ b/tensorcircuit/backends/tensorflow_backend.py
@@ -577,17 +577,9 @@ class TensorFlowBackend(tensorflow_backend.TensorFlowBackend, ExtendedBackend): 
         return tf.clip_by_value(a, a_min, a_max)
 
     def floor(self, x: Tensor) -> Tensor:
-        dtype_str = x.dtype.name if hasattr(x.dtype, "name") else str(x.dtype)
-        if x.dtype.is_floating:
-            return tf.math.floor(x)
-        elif x.dtype.is_integer:
+        if x.dtype.is_integer:
             return x
-        elif x.dtype.is_complex:
-            raise TypeError(
-                f"tf.math.floor does not support complex dtype ({dtype_str})"
-            )
-        else:
-            raise TypeError(f"Unsupported dtype for floor: {dtype_str}")
+        return tf.math.floor(x)
 
     def concat(self, a: Sequence[Tensor], axis: int = 0) -> Tensor:
         return tf.concat(a, axis=axis)

--- a/tensorcircuit/backends/tensorflow_backend.py
+++ b/tensorcircuit/backends/tensorflow_backend.py
@@ -576,10 +576,10 @@ class TensorFlowBackend(tensorflow_backend.TensorFlowBackend, ExtendedBackend): 
     def clip(self, a: Tensor, a_min: Tensor, a_max: Tensor) -> Tensor:
         return tf.clip_by_value(a, a_min, a_max)
 
-    def floor(self, x: Tensor) -> Tensor:
-        if x.dtype.is_integer:
-            return x
-        return tf.math.floor(x)
+    def floor(self, a: Tensor) -> Tensor:
+        if a.dtype.is_integer:
+            return a
+        return tf.math.floor(a)
 
     def concat(self, a: Sequence[Tensor], axis: int = 0) -> Tensor:
         return tf.concat(a, axis=axis)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -436,6 +436,39 @@ def test_backend_methods_2(backend):
 
 
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb"), lf("torchb")])
+def test_backend_floor(backend):
+    """Test floor method (element-wise, dtype/device preservation, integers unchanged)."""
+    a = tc.backend.convert_to_tensor([-1.7, -0.0, 0.0, 0.2, 3.9])
+    r = tc.backend.floor(a)
+    expected = tc.backend.convert_to_tensor([-2.0, -0.0, 0.0, 0.0, 3.0])
+    np.testing.assert_allclose(r, expected, atol=1e-6)
+    assert tc.backend.dtype(r) == tc.backend.dtype(a)
+    assert tc.backend.device(r) == tc.backend.device(a)
+    ai = tc.backend.convert_to_tensor([0, 1, -2, 3])
+    ri = tc.backend.floor(ai)
+    np.testing.assert_allclose(ri, ai)
+
+
+@pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb"), lf("torchb")])
+def test_backend_clip(backend):
+    """Test clip method (scalar/tensor bounds, broadcasting, dtype/device)."""
+    a = tc.backend.convert_to_tensor([-2.0, -0.5, 0.0, 0.5, 10.0])
+    a_min = tc.backend.convert_to_tensor(-1.0)
+    a_max = tc.backend.convert_to_tensor(1.0)
+    r = tc.backend.clip(a, a_min, a_max)
+    expected = tc.backend.convert_to_tensor([-1.0, -0.5, 0.0, 0.5, 1.0])
+    np.testing.assert_allclose(r, expected, atol=1e-6)
+    assert tc.backend.dtype(r) == tc.backend.dtype(a)
+    assert tc.backend.device(r) == tc.backend.device(a)
+    a2 = tc.backend.convert_to_tensor([[-5.0, 0.0, 5.0], [1.0, 2.0, 3.0]])
+    a2_min = tc.backend.convert_to_tensor([[-1.0, 0.0, 0.0], [0.0, 1.0, 2.0]])
+    a2_max = tc.backend.convert_to_tensor([[0.0, 0.0, 4.0], [1.0, 2.0, 2.0]])
+    r2 = tc.backend.clip(a2, a2_min, a2_max)
+    expected2 = tc.backend.convert_to_tensor([[-1.0, 0.0, 4.0], [1.0, 2.0, 2.0]])
+    np.testing.assert_allclose(r2, expected2, atol=1e-6)
+
+
+@pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb"), lf("torchb")])
 def test_device_cpu_only(backend):
     a = tc.backend.ones([])
     dev_str = tc.backend.device(a)


### PR DESCRIPTION
Add clip() and floor() functions for backends. Add reshaped() function to abstractbackend as a preparation for qudit systems. Add corresponding tests in tests/test_backends.py for clip() and floor().