### PR TITLE
🔒 [security fix] Prevent command injection in render_pdf via latex argument

### DIFF
--- a/tensorcircuit/vis.py
+++ b/tensorcircuit/vis.py
@@ -310,6 +310,15 @@ def render_pdf(
         filepath = os.getcwd()
     if not latex:
         latex = "pdflatex"
+    else:
+        # Security fix: validate latex command
+        basename = os.path.basename(latex)
+        if basename not in ["pdflatex", "xelatex", "lualatex", "latex"]:
+            raise ValueError(
+                f"Invalid latex command: {latex}. "
+                "Only pdflatex, xelatex, lualatex, and latex are allowed."
+            )
+
     if not filename:
         filename = str(uuid4())
     if filename.endswith(".pdf"):


### PR DESCRIPTION
The `render_pdf` function in `tensorcircuit/vis.py` previously accepted an unvalidated `latex` argument which was passed directly to `subprocess.run` as the executable. This presented a security risk where an attacker could execute arbitrary binaries.

The fix introduces a validation step that checks the provided `latex` command against an allowlist of safe LaTeX engines. It uses `os.path.basename()` to ensure that even if a full path is provided, the executable itself must be one of the permitted names (`pdflatex`, `xelatex`, `lualatex`, or `latex`).

Changes:
- Modified `tensorcircuit/vis.py:render_pdf` to include validation of the `latex` argument.
- Raised `ValueError` for invalid `latex` commands.


---
*PR created automatically by Jules for task [8360408832736177422](https://jules.google.com/task/8360408832736177422) started by @refraction-ray*