### PR TITLE
Refactor layer functions to templates/layers (Final)

### DIFF
--- a/tensorcircuit/templates/__init__.py
+++ b/tensorcircuit/templates/__init__.py
@@ -7,5 +7,6 @@ from . import measurements
 from . import conversions
 from . import lattice
 from . import hamiltonians
+from . import layers
 
 costfunctions = measurements


### PR DESCRIPTION
The task was to move and refactor layer functions to `templates/layers`. 

As instructed, I moved the core native layer functions to `tensorcircuit/templates/layers.py` and refactored them for better backend independence. I also fixed a bug in `bitfliplayer_mc`. 

Regarding the `applications` submodule, since it is deprecated, I have simplified `tensorcircuit/applications/layers.py` to only contain the original Cirq-related code and its necessary dependencies, effectively removing the native layer functions from that location. 

The new `layers` template is now properly integrated into the `tc.templates` namespace.

---
*PR created automatically by Jules for task [13920108049073077316](https://jules.google.com/task/13920108049073077316) started by @refraction-ray*