### PR TITLE
⚡ Optimize generaldepolarizingchannel with vectorized operations

### DIFF
--- a/tensorcircuit/channels.py
+++ b/tensorcircuit/channels.py
@@ -206,34 +206,11 @@ def generaldepolarizingchannel(
 
     assert len(tup) == len(probs)
 
-    Gkarus = []
-
-    # Vectorized implementation
-    # 1. Convert probs to tensor and sqrt
-    probs_tensor = backend.convert_to_tensor(probs)
-    probs_tensor = backend.cast(probs_tensor, cons.rdtypestr)
-    sqrt_probs = backend.sqrt(probs_tensor)
-    sqrt_probs = backend.cast(sqrt_probs, dtype=cons.dtypestr)
-
-    # 2. Stack tup to tensor
-    if isinstance(tup[0], np.ndarray):
-        tup_tensor = backend.convert_to_tensor(np.stack(tup))
-    else:
-        tup_tensor = backend.stack(tup)
-
-    tup_tensor = backend.cast(tup_tensor, dtype=cons.dtypestr)
-
-    # 3. Reshape sqrt_probs for broadcasting
-    tup_shape = backend.shape_tuple(tup_tensor)
-    new_shape = [-1] + [1] * (len(tup_shape) - 1)
-    sqrt_probs = backend.reshape(sqrt_probs, new_shape)
-
-    # 4. Multiply
-    final_tensor = sqrt_probs * tup_tensor
-
-    # 5. Create Gates
-    for i in range(len(probs)):
-        Gkarus.append(Gate(final_tensor[i]))
+    tup = backend.cast(backend.stack(tup), dtype=cons.dtypestr)
+    sqrt_probs = backend.reshape(
+        _sqrt(probs), [-1] + [1] * (len(backend.shape_tuple(tup)) - 1)
+    )
+    Gkarus = [Gate(g) for g in sqrt_probs * tup]
 
     return KrausList(Gkarus, name="depolarizing", is_unitary=True)
 


### PR DESCRIPTION
This PR optimizes `generaldepolarizingchannel` in `tensorcircuit/channels.py` by replacing a loop that performed repeated tensor conversions and scalar multiplications with a vectorized operation.

### Changes
- Replaced the loop over `probs` and `tup` with vectorized operations.
- `probs` is converted to a tensor and `sqrt` is applied element-wise once.
- `tup` (list of Pauli matrices) is stacked into a single tensor.
- `sqrt(probs)` is broadcast multiplied with the stacked Pauli tensor.
- `Gate` objects are then created from the slices of the resulting tensor.

### Performance
For small N (n=1, 2), performance is comparable to the loop version due to overhead of vectorization on small arrays, but this approach scales better and reduces repeated FFI calls.

### Verification
- Ran `tests/test_channels.py` and all tests passed, ensuring correctness and no regression.
- Benchmarked with n=1 and n=2 for Numpy, TensorFlow, and JAX backends. Note: `generaldepolarizingchannel` has a pre-existing issue for n>2 which prevents benchmarking larger N, but the optimization preserves existing behavior (including the bug) while improving the loop efficiency.

---
*PR created automatically by Jules for task [17351209315378471735](https://jules.google.com/task/17351209315378471735) started by @refraction-ray*