### PR TITLE
test: Verify NotImplementedError for QuditCircuit with dim > 36

### DIFF
--- a/tests/test_quditcircuit.py
+++ b/tests/test_quditcircuit.py
@@ -347,6 +347,8 @@ def test_quditcircuit_set_dim_validation():
         tc.QuditCircuit(1, 2)
     with pytest.raises(ValueError):
         tc.QuditCircuit(1, 2.5)  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError):
+        tc.QuditCircuit(1, 37)
 
 
 @pytest.mark.parametrize("backend", [lf("jaxb"), lf("tfb"), lf("torchb")])


### PR DESCRIPTION
This PR addresses a testing gap by adding a test case to verify that `QuditCircuit` raises `NotImplementedError` when initialized with a dimension greater than 36. This limitation exists because the current string-encoded IO only supports dimensions up to 36 (using digits 0-9 and A-Z).

## Changes
- Modified `tests/test_quditcircuit.py`: Added a new assertion in `test_quditcircuit_set_dim_validation` to check for `NotImplementedError` when `dim=37`.

## Verification
- Ran `pytest tests/test_quditcircuit.py` and confirmed all tests passed, including the new test case.
- Verified that the test fails if the assertion is changed to `ValueError`, confirming the test is effective.

---
*PR created automatically by Jules for task [8065592887853955542](https://jules.google.com/task/8065592887853955542) started by @refraction-ray*