### PR TITLE
Optimize Pauli string generation in generaldepolarizingchannel

### DIFF
--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -41,6 +41,9 @@ def test_dep(backend):
     cs = tc.channels.generaldepolarizingchannel(0.02, 2)
     tc.channels.kraus_identity_check(cs)
 
+    cs3 = tc.channels.generaldepolarizingchannel(0.01, 3)
+    tc.channels.kraus_identity_check(cs3)
+
     cs2 = tc.channels.isotropicdepolarizingchannel(0.02 * 15, 2)
     for c1, c2 in zip(cs, cs2):
         np.testing.assert_allclose(c1.tensor, c2.tensor)


### PR DESCRIPTION
Replaced inefficient nested loop construction of Pauli strings with a vectorized numpy broadcasting implementation.
This improves performance significantly for larger qubit numbers and fixes a bug where the original implementation failed for num_qubits >= 3.
Added a test case for num_qubits=3 to prevent regression.

---
*PR created automatically by Jules for task [11479252523809441439](https://jules.google.com/task/11479252523809441439) started by @refraction-ray*