### PR TITLE
🧪 add test for invalid QuOperator initialization

### DIFF
--- a/tests/test_quantum.py
+++ b/tests/test_quantum.py
@@ -25,6 +25,18 @@ decimal = 5
 
 
 @pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
+def test_invalid_quoperator_init(backend):
+    with pytest.raises(
+        ValueError, match="At least one reference node is required to specify a scalar"
+    ):
+        qu.QuOperator([], [])
+    with pytest.raises(
+        ValueError, match="At least one reference node is required to specify a scalar"
+    ):
+        qu.QuScalar([])
+
+
+@pytest.mark.parametrize("backend", [lf("npb"), lf("tfb"), lf("jaxb")])
 def test_constructor(backend):
     psi_tensor = np.random.rand(2, 2)
     psi_node = tn.Node(psi_tensor)


### PR DESCRIPTION
The testing improvement addresses a gap in the validation of `QuOperator` and `QuScalar` initialization. 

🎯 **What:** The testing gap addressed is the lack of a unit test for the case where a `QuOperator` is initialized as a scalar (empty `in_edges` and `out_edges`) without any `ref_nodes`.
📊 **Coverage:** The new test case `test_invalid_quoperator_init` covers:
- `QuOperator([], [])` raising `ValueError` with the message "At least one reference node is required to specify a scalar".
- `QuScalar([])` raising the same `ValueError`.
✨ **Result:** Improved reliability of the quantum module by ensuring class invariants are properly tested across all backends.

---
*PR created automatically by Jules for task [12354484370709117425](https://jules.google.com/task/12354484370709117425) started by @refraction-ray*