### PR TITLE
🧹 Remove duplicated TFIM1Denergy and Heisenberg1Denergy implementations

### DIFF
--- a/tensorcircuit/applications/utils.py
+++ b/tensorcircuit/applications/utils.py
@@ -20,6 +20,7 @@ except ImportError as e:
 from ..circuit import Circuit
 from .. import gates as G
 from ..gates import array_to_tensor, num_to_tensor
+from .physics.baseline import TFIM1Denergy, Heisenberg1Denergy
 
 Array = Any
 Tensor = Any
@@ -389,55 +390,3 @@ def repr2array(inputs: str) -> Array:
     return np.array(outputs)
 
 
-# duplicated, will remove later
-# use the version in applications.physics.baseline.py
-def TFIM1Denergy(
-    L: int, Jzz: float = 1.0, Jx: float = 1.0, Pauli: bool = True
-) -> float:
-    # PBC
-    # nice tutorial: https://arxiv.org/pdf/2009.09208.pdf
-    # further investigation on 1 TFIM solution structure is required
-    # will fail on AFM phase Jzz>Jx and Jzz>0 and odd sites (frustration in boundary)
-    e = 0
-    if Pauli:
-        Jx *= 2
-        Jzz *= 4
-    for i in range(L):
-        q = np.pi * (2 * i - (1 + (-1) ** L) / 2) / L
-        e -= np.abs(Jx) / 2 * np.sqrt(1 + Jzz**2 / 4 / Jx**2 - Jzz / Jx * np.cos(q))
-    return e
-
-
-def Heisenberg1Denergy(L: int, Pauli: bool = True, maxiters: int = 1000) -> float:
-    # PBC
-    error = 1e-15
-    eps = 1e-20  # avoid zero division
-    phi = np.zeros([L // 2, L // 2])
-    phi2 = np.zeros([L // 2, L // 2])
-    lamb = np.array([2 * i + 1 for i in range(L // 2)])
-    for _ in range(maxiters):
-        k = 1 / L * (2 * np.pi * lamb + np.sum(phi, axis=-1) - np.diag(phi))
-        for i in range(L // 2):
-            for j in range(L // 2):
-                phi2[i, j] = (
-                    np.arctan(
-                        2
-                        / (
-                            1 / (np.tan(k[i] / 2) + eps)
-                            - 1 / (np.tan(k[j] / 2) + eps)
-                            + eps
-                        )
-                    )
-                    * 2
-                )
-        if np.allclose(phi, phi2, rtol=error):  # converged
-            break
-        phi = phi2.copy()
-    else:
-        raise ValueError(
-            "the maxiters %s is too small for bethe ansatz to converge" % maxiters
-        )
-    e = -np.sum(1 - np.cos(k)) + L / 4
-    if Pauli is True:
-        e *= 4
-    return e  # type: ignore


### PR DESCRIPTION
This PR removes duplicated code in `tensorcircuit/applications/utils.py` as suggested by the author's comments. Specifically, it:
- Removes local implementations of `TFIM1Denergy` and `Heisenberg1Denergy`.
- Imports these functions from `.physics.baseline` to preserve the module's API.
- Improves maintainability by consolidating physics baseline calculations.
Verification was performed using a mock-based execution script to confirm the functions are correctly re-exposed and consistent with the baseline implementations, despite the limited environment dependencies.

---
*PR created automatically by Jules for task [14667189094528384594](https://jules.google.com/task/14667189094528384594) started by @refraction-ray*