### PR TITLE
Include PyTorch in gpu_memory_share utility

### DIFF
--- a/tensorcircuit/utils.py
+++ b/tensorcircuit/utils.py
@@ -18,14 +18,26 @@ def gpu_memory_share(flag: bool = True) -> None:
     :type flag: bool
     :return: None
     """
-    # TODO(@refraction-ray): the default torch behavior should be True
-    # preallocate behavior for torch to be investigated
+    # torch default behavior is already sharing-friendly (allow growth)
     if flag is True:
         os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"
         os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+        if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+        elif "expandable_segments:True" not in os.environ["PYTORCH_CUDA_ALLOC_CONF"]:
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] += ",expandable_segments:True"
     else:
         os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "false"
         os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "true"
+        if "PYTORCH_CUDA_ALLOC_CONF" in os.environ:
+            conf = os.environ["PYTORCH_CUDA_ALLOC_CONF"]
+            os.environ["PYTORCH_CUDA_ALLOC_CONF"] = ",".join(
+                [
+                    p.strip()
+                    for p in conf.split(",")
+                    if p.strip() != "expandable_segments:True"
+                ]
+            )
 
 
 def return_partial(


### PR DESCRIPTION
I have updated the `gpu_memory_share` function in `tensorcircuit/utils.py` to include support for PyTorch. 

Specifically:
- When `flag=True` (the default), `expandable_segments:True` is appended to the `PYTORCH_CUDA_ALLOC_CONF` environment variable if it's not already present. This enables a memory-sharing friendly mode in PyTorch (available in version 2.1+).
- When `flag=False`, `expandable_segments:True` is removed from `PYTORCH_CUDA_ALLOC_CONF`, reverting to the default or other user-specified behavior.
- The logic ensures that existing user-defined configurations in `PYTORCH_CUDA_ALLOC_CONF` are preserved.
- The TODO regarding investigating PyTorch behavior has been addressed and removed, as PyTorch's default caching allocator is already sharing-friendly, and `expandable_segments:True` further optimizes this.

I have verified the logic with standalone scripts ensuring all edge cases (empty environment, existing config, multiple toggles) are handled correctly. All temporary test files have been removed.

---
*PR created automatically by Jules for task [17265347275898146321](https://jules.google.com/task/17265347275898146321) started by @refraction-ray*