### PR TITLE
🔒 fix remote code execution vulnerability in qiskit compiler

### DIFF
--- a/tensorcircuit/compiler/qiskit_compiler.py
+++ b/tensorcircuit/compiler/qiskit_compiler.py
@@ -2,12 +2,42 @@
 compiler interface via qiskit
 """
 
+import ast
 import re
 from typing import Any, Dict, Optional
 
 from ..abstractcircuit import AbstractCircuit
 from ..circuit import Circuit
 from ..translation import qiskit_from_qasm_str_ordered_measure, get_qiskit_qasm
+
+
+def _safe_eval(s: str) -> Any:
+    operators = {
+        ast.Add: lambda a, b: a + b,
+        ast.Sub: lambda a, b: a - b,
+        ast.Mult: lambda a, b: a * b,
+        ast.Div: lambda a, b: a / b,
+        ast.Pow: lambda a, b: a ** b,
+        ast.USub: lambda a: -a,
+        ast.UAdd: lambda a: a,
+    }
+
+    def _eval(node: Any) -> Any:
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.Num):  # python < 3.8
+            return node.n
+        if isinstance(node, ast.BinOp):
+            return operators[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp):
+            return operators[type(node.op)](_eval(node.operand))
+        if isinstance(node, ast.Tuple):
+            return tuple(_eval(n) for n in node.elts)
+        raise ValueError(f"Unsupported node type: {type(node)}")
+
+    return _eval(ast.parse(s, mode="eval"))
 
 
 def _free_pi(s: str) -> str:
@@ -21,7 +51,7 @@ def _free_pi(s: str) -> str:
             rs.append(r)
         else:
             v = r[inc.start() : inc.end()]
-            v = eval(v)
+            v = _safe_eval(v)
             if not isinstance(v, tuple):
                 r = r[: inc.start()] + "(" + str(v) + ")" + r[inc.end() :]
             else:  # u gate case


### PR DESCRIPTION
🎯 **What:** Replaced unsafe `eval()` with a restricted AST-based evaluator `_safe_eval` in the `_free_pi` function within `tensorcircuit/compiler/qiskit_compiler.py`.

⚠️ **Risk:** The use of `eval()` on parameter strings extracted from QASM allowed for arbitrary Python code execution. If an attacker could provide a malicious QASM string to the compiler, they could execute arbitrary commands on the system running the code.

🛡️ **Solution:** Implemented `_safe_eval`, which parses the input string into an Abstract Syntax Tree (AST) and only permits a strict allowlist of nodes: constants (numbers), binary operations (addition, subtraction, multiplication, division, power), unary operations (plus, minus), and tuples. Any other node type, such as function calls or imports, triggers a `ValueError`. This ensures that mathematical expressions commonly found in QASM (where `pi` is pre-replaced with its numerical value) can still be evaluated securely.

---
*PR created automatically by Jules for task [15022396937964748523](https://jules.google.com/task/15022396937964748523) started by @refraction-ray*