### PR TITLE
fix: resolve hardcoded complex128/complex64 and improve pure pytree robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,17 @@
 
 - Add support for OMECO contraction path finder.
 
+### Changed
+
+- Replace hardcoded `np.complex128`/`np.complex64` with `cons.npdtype`/`dtypestr` in gates and translation modules, making the codebase respect `tc.set_dtype()`.
+
+- Add pure Python tree utility functions (`_pure_tree_flatten`, `_pure_tree_unflatten`, `_pure_tree_map`) as TensorFlow fallback in the abstract backend, with leaf broadcasting support.
+
 ### Fixed
 
-- Fix sparse Pauli propagation aggregation, initial truncation, multi-word bit-packing, and unsupported multi-qubit gate handling.
+- Fix `numpy_backend.cast()`, `jax_backend.cast()`, and `pytorch_backend.cast()` to correctly handle Python scalar inputs.
 
+- Fix sparse Pauli propagation aggregation, initial truncation, multi-word bit-packing, and unsupported multi-qubit gate handling.
 ## v1.6.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@
 
 - Add support for OMECO contraction path finder.
 
+- Add pure-Python pytree utilities for the abstract backend.
+
 ### Changed
 
 - Replace hardcoded `np.complex128`/`np.complex64` with `cons.npdtype`/`dtypestr` in gates and translation modules, making the codebase respect `tc.set_dtype()`.
-
-- Align pure pytree utilities (`_pure_tree_flatten`, `_pure_tree_unflatten`, `_pure_tree_map`) with JAX `tree_util` semantics, including `OrderedDict` (insertion-order) and `defaultdict` (sorted keys + `default_factory`) round-trip support.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Replace hardcoded `np.complex128`/`np.complex64` with `cons.npdtype`/`dtypestr` in gates and translation modules, making the codebase respect `tc.set_dtype()`.
 
-- Add pure Python tree utility functions (`_pure_tree_flatten`, `_pure_tree_unflatten`, `_pure_tree_map`) as TensorFlow fallback in the abstract backend, with leaf broadcasting support.
+- **Align `_pure_tree_flatten`, `_pure_tree_unflatten`, `_pure_tree_map` with JAX `tree_util` semantics**: `None` is now an empty pytree (0 leaves); dict keys are sorted; namedtuple is tracked as a distinct type from plain tuple; `tree_map` enforces strict structure matching (no scalar broadcast); `unflatten` raises `ValueError` on leaf count mismatch. Added comprehensive test suite (`test_pure_pytree.py`) with JAX comparison tests.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Replace hardcoded `np.complex128`/`np.complex64` with `cons.npdtype`/`dtypestr` in gates and translation modules, making the codebase respect `tc.set_dtype()`.
 
-- **Align `_pure_tree_flatten`, `_pure_tree_unflatten`, `_pure_tree_map` with JAX `tree_util` semantics**: `None` is now an empty pytree (0 leaves); dict keys are sorted; namedtuple is tracked as a distinct type from plain tuple; `tree_map` enforces strict structure matching (no scalar broadcast); `unflatten` raises `ValueError` on leaf count mismatch. Added comprehensive test suite (`test_pure_pytree.py`) with JAX comparison tests.
+- Align pure pytree utilities (`_pure_tree_flatten`, `_pure_tree_unflatten`, `_pure_tree_map`) with JAX `tree_util` semantics, including `OrderedDict` (insertion-order) and `defaultdict` (sorted keys + `default_factory`) round-trip support.
 
 ### Fixed
 

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -41,7 +41,8 @@ class _TreeDef:
                 )
             return leaves.pop(0)
         if self.typ is dict:
-            assert self.sorted_keys is not None
+            if self.sorted_keys is None:
+                raise ValueError("sorted_keys required for dict treedef")
             return {
                 k: child.unflatten(leaves)
                 for k, child in zip(self.sorted_keys, self.children)

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -16,6 +16,71 @@ from ..utils import return_partial
 Tensor = Any
 
 
+def _is_leaf(obj: Any) -> bool:
+    """Check if obj is a leaf (not a list/tuple/dict container)."""
+    return not isinstance(obj, (list, tuple, dict))
+
+
+def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], Any]:
+    """
+    Pure Python tree flattening.
+    Returns (leaves, treedef) where treedef is the original pytree structure.
+    """
+    if _is_leaf(pytree):
+        return [pytree], pytree
+    leaves: List[Any] = []
+    if isinstance(pytree, dict):
+        for v in pytree.values():
+            child_leaves, _ = _pure_tree_flatten(v)
+            leaves.extend(child_leaves)
+    else:  # list or tuple
+        for v in pytree:
+            child_leaves, _ = _pure_tree_flatten(v)
+            leaves.extend(child_leaves)
+    return leaves, pytree
+
+
+def _pure_tree_unflatten(treedef: Any, leaves: List[Any]) -> Any:
+    """
+    Pure Python tree unflattening using the original pytree structure as treedef.
+    Consumes leaves from the front of the list.
+    """
+    if _is_leaf(treedef):
+        return leaves.pop(0)
+    if isinstance(treedef, dict):
+        return {k: _pure_tree_unflatten(v, leaves) for k, v in treedef.items()}
+    if isinstance(treedef, tuple):
+        return tuple(_pure_tree_unflatten(v, leaves) for v in treedef)
+    # list
+    return [_pure_tree_unflatten(v, leaves) for v in treedef]
+
+
+def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
+    """
+    Pure Python tree_map. Applies f element-wise to corresponding leaves.
+    Supports broadcasting of leaf arguments to match the structure of non-leaf arguments,
+    consistent with tf.nest.map_structure.
+    """
+    if all(_is_leaf(p) for p in pytrees):
+        return f(*pytrees)
+    first = next(p for p in pytrees if not _is_leaf(p))
+    if isinstance(first, dict):
+        return {
+            k: _pure_tree_map(f, *(p if _is_leaf(p) else p[k] for p in pytrees))
+            for k in first
+        }
+    if isinstance(first, tuple):
+        return tuple(
+            _pure_tree_map(f, *(p if _is_leaf(p) else p[i] for p in pytrees))
+            for i in range(len(first))
+        )
+    # list
+    return [
+        _pure_tree_map(f, *(p if _is_leaf(p) else p[i] for p in pytrees))
+        for i in range(len(first))
+    ]
+
+
 class ExtendedBackend:
     """
     Add tensorcircuit specific backend methods, especially with their docstrings.
@@ -1229,17 +1294,10 @@ class ExtendedBackend:
         :type f: Callable[..., Any]
         :param pytrees: inputs as any python structure
         :type pytrees: Any
-        :raises NotImplementedError: raise when neither tensorflow or jax is installed.
         :return: The new tree map with the same structure but different values.
         :rtype: Any
         """
-        try:
-            import tensorflow as tf
-
-        except ImportError:
-            raise NotImplementedError("No installed ML backend for `tree_map`")
-
-        return tf.nest.map_structure(f, *pytrees)
+        return _pure_tree_map(f, *pytrees)
 
     def tree_flatten(self: Any, pytree: Any) -> Tuple[Any, Any]:
         """
@@ -1251,16 +1309,7 @@ class ExtendedBackend:
             which can be used for later unflatten
         :rtype: Tuple[Any, Any]
         """
-        try:
-            import tensorflow as tf
-
-        except ImportError:
-            raise NotImplementedError("No installed ML backend for `tree_flatten`")
-
-        leaves = tf.nest.flatten(pytree)
-        treedef = pytree
-
-        return leaves, treedef
+        return _pure_tree_flatten(pytree)
 
     def tree_unflatten(self: Any, treedef: Any, leaves: Any) -> Any:
         """
@@ -1273,13 +1322,8 @@ class ExtendedBackend:
         :return: Packed pytree
         :rtype: Any
         """
-        try:
-            import tensorflow as tf
-
-        except ImportError:
-            raise NotImplementedError("No installed ML backend for `tree_unflatten`")
-
-        return tf.nest.pack_sequence_as(treedef, leaves)
+        leaves_copy = list(leaves)
+        return _pure_tree_unflatten(treedef, leaves_copy)
 
     def to_dlpack(self: Any, a: Tensor) -> Any:
         """

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -16,69 +16,190 @@ from ..utils import return_partial
 Tensor = Any
 
 
+class _TreeDef:
+    """A JAX-compatible treedef that records pytree structure for unflattening."""
+
+    __slots__ = ("typ", "sorted_keys", "children", "num_leaves")
+
+    def __init__(
+        self,
+        typ: type,
+        sorted_keys: Optional[Tuple[str, ...]],
+        children: Tuple["_TreeDef", ...],
+        num_leaves: int,
+    ) -> None:
+        self.typ = typ
+        self.sorted_keys = sorted_keys  # non-None only for dict
+        self.children = children
+        self.num_leaves = num_leaves
+
+    def unflatten(self, leaves: list) -> Any:
+        if self.typ is _LEAF:
+            if not leaves:
+                raise ValueError(
+                    "Not enough leaves to unflatten. Expected at least 1, got 0."
+                )
+            return leaves.pop(0)
+        if self.typ is dict:
+            return {
+                k: child.unflatten(leaves)
+                for k, child in zip(self.sorted_keys, self.children)
+            }
+        if self.typ is _NONE_TYPE:
+            return None
+        if issubclass(self.typ, tuple):
+            result = tuple(child.unflatten(leaves) for child in self.children)
+            if self.typ is not tuple:
+                return self.typ(*result)
+            return result
+        # list
+        return [child.unflatten(leaves) for child in self.children]
+
+
+class _LeafSentinel:
+    """Sentinel type so that ``_TreeDef`` can represent a leaf node."""
+
+    pass
+
+
+_LEAF = _LeafSentinel
+_NONE_TYPE = type(None)
+
+
 def _is_leaf(obj: Any) -> bool:
-    """Check if obj is a leaf (not a list/tuple/dict container)."""
-    return not isinstance(obj, (list, tuple, dict))
+    """Check whether *obj* is a leaf managed by the pure-pytree machinery.
+
+    Everything that is not a recognised pytree container (dict, list, tuple,
+    namedtuple, or ``None``) is a leaf.  This deliberately matches JAX
+    semantics for the types supported here.
+    """
+    if obj is None:
+        return False
+    if isinstance(obj, dict):
+        return False
+    if isinstance(obj, (list, tuple)):
+        return False
+    return True
 
 
-def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], Any]:
+def _meta_type(obj: Any) -> type:
+    """Return the structural type tag for *obj* (tuple vs namedtuple vs ...)."""
+    if isinstance(obj, tuple) and hasattr(type(obj), "_fields"):
+        return type(obj)
+    return type(obj)
+
+
+def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], _TreeDef]:
     """
-    Pure Python tree flattening.
-    Returns (leaves, treedef) where treedef is the original pytree structure.
+    Pure Python tree flattening with JAX-compatible semantics.
+
+    Key differences from a naïve implementation:
+    * ``None`` is an empty pytree (0 leaves), not a leaf.
+    * ``dict`` keys are iterated in **sorted** order so that leaves are
+      deterministic regardless of insertion order.
+    * ``namedtuple`` is tracked as a separate type from plain ``tuple``.
     """
+    if pytree is None:
+        return [], _TreeDef(_NONE_TYPE, None, (), 0)
     if _is_leaf(pytree):
-        return [pytree], pytree
+        return [pytree], _TreeDef(_LEAF, None, (), 1)
     leaves: List[Any] = []
     if isinstance(pytree, dict):
-        for v in pytree.values():
-            child_leaves, _ = _pure_tree_flatten(v)
+        sorted_keys = tuple(sorted(pytree.keys()))
+        children = []
+        for k in sorted_keys:
+            child_leaves, child_td = _pure_tree_flatten(pytree[k])
             leaves.extend(child_leaves)
-    else:  # list or tuple
-        for v in pytree:
-            child_leaves, _ = _pure_tree_flatten(v)
-            leaves.extend(child_leaves)
-    return leaves, pytree
+            children.append(child_td)
+        return leaves, _TreeDef(dict, sorted_keys, tuple(children), len(leaves))
+    # list, tuple, namedtuple
+    children = []
+    for v in pytree:
+        child_leaves, child_td = _pure_tree_flatten(v)
+        leaves.extend(child_leaves)
+        children.append(child_td)
+    return leaves, _TreeDef(_meta_type(pytree), None, tuple(children), len(leaves))
 
 
-def _pure_tree_unflatten(treedef: Any, leaves: List[Any]) -> Any:
+def _pure_tree_unflatten(treedef: _TreeDef, leaves: List[Any]) -> Any:
     """
-    Pure Python tree unflattening using the original pytree structure as treedef.
-    Consumes leaves from the front of the list.
+    Pure Python tree unflattening using a :class:`_TreeDef` produced by
+    :func:`_pure_tree_flatten`.  **Copies** *leaves* so that the original
+    list is not mutated.  Raises :class:`ValueError` when the number of
+    leaves does not match *treedef*.
     """
-    if _is_leaf(treedef):
-        return leaves.pop(0)
-    if isinstance(treedef, dict):
-        return {k: _pure_tree_unflatten(v, leaves) for k, v in treedef.items()}
-    if isinstance(treedef, tuple):
-        return tuple(_pure_tree_unflatten(v, leaves) for v in treedef)
-    # list
-    return [_pure_tree_unflatten(v, leaves) for v in treedef]
+    leaves_copy = list(leaves)
+    result = treedef.unflatten(leaves_copy)
+    if leaves_copy:
+        raise ValueError(
+            f"Too many leaves for treedef: expected {treedef.num_leaves}, "
+            f"got {len(leaves)}."
+        )
+    return result
+
+
+def _treedefs_compatible(a: _TreeDef, b: _TreeDef) -> bool:
+    """Check whether two treedefs have compatible structure for tree_map."""
+    if a.typ is not b.typ:
+        return False
+    if a.typ is _LEAF:
+        return True
+    if a.typ is _NONE_TYPE:
+        return True
+    if a.typ is dict:
+        if a.sorted_keys != b.sorted_keys:
+            return False
+        return all(
+            _treedefs_compatible(ac, bc) for ac, bc in zip(a.children, b.children)
+        )
+    if len(a.children) != len(b.children):
+        return False
+    return all(_treedefs_compatible(ac, bc) for ac, bc in zip(a.children, b.children))
 
 
 def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
     """
-    Pure Python tree_map. Applies f element-wise to corresponding leaves.
-    Supports broadcasting of leaf arguments to match the structure of non-leaf arguments,
-    consistent with tf.nest.map_structure.
+    Pure Python ``tree_map`` with JAX-compatible semantics.
+
+    Applies *f* element-wise to corresponding leaves.  All non-leaf
+    arguments must share the **same** pytree structure (type, key order,
+    and nesting); a :class:`ValueError` is raised on mismatch.
     """
+    if not pytrees:
+        raise TypeError("_pure_tree_map requires at least one pytree argument")
+
+    # Fast path when all arguments are leaves
     if all(_is_leaf(p) for p in pytrees):
         return f(*pytrees)
-    first = next(p for p in pytrees if not _is_leaf(p))
-    if isinstance(first, dict):
-        return {
-            k: _pure_tree_map(f, *(p if _is_leaf(p) else p[k] for p in pytrees))
-            for k in first
-        }
-    if isinstance(first, tuple):
-        return tuple(
-            _pure_tree_map(f, *(p if _is_leaf(p) else p[i] for p in pytrees))
-            for i in range(len(first))
-        )
-    # list
-    return [
-        _pure_tree_map(f, *(p if _is_leaf(p) else p[i] for p in pytrees))
-        for i in range(len(first))
-    ]
+
+    # Flatten and validate structure
+    flat_results = []
+    first_treedef = None
+    first_leaves: Optional[List[Any]] = None
+    for tree in pytrees:
+        leaves, td = _pure_tree_flatten(tree)
+        if first_treedef is None:
+            first_treedef = td
+            first_leaves = leaves
+        else:
+            if not _treedefs_compatible(first_treedef, td):
+                raise ValueError(
+                    "Pytree structure mismatch: all non-leaf arguments to "
+                    "tree_map must have the same structure."
+                )
+
+    assert first_leaves is not None and first_treedef is not None
+    # Collect all leaf lists
+    all_leaves: List[List[Any]] = []
+    for tree in pytrees:
+        leaves, _ = _pure_tree_flatten(tree)
+        all_leaves.append(leaves)
+
+    # Apply f to corresponding leaves
+    for i in range(first_treedef.num_leaves):
+        flat_results.append(f(*(ls[i] for ls in all_leaves)))
+
+    return _pure_tree_unflatten(first_treedef, flat_results)
 
 
 class ExtendedBackend:
@@ -1322,8 +1443,7 @@ class ExtendedBackend:
         :return: Packed pytree
         :rtype: Any
         """
-        leaves_copy = list(leaves)
-        return _pure_tree_unflatten(treedef, leaves_copy)
+        return _pure_tree_unflatten(treedef, leaves)
 
     def to_dlpack(self: Any, a: Tensor) -> Any:
         """

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -3,11 +3,11 @@ Backend magic inherited from tensornetwork: abstract backend
 """
 
 # pylint: disable=invalid-name
-# pylint: disable=unused-variable
 
+from collections import OrderedDict, defaultdict
 from functools import reduce, partial
 from operator import mul
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Union
 
 import math
 import numpy as np
@@ -19,7 +19,7 @@ Tensor = Any
 class _TreeDef:
     """A JAX-compatible treedef that records pytree structure for unflattening."""
 
-    __slots__ = ("typ", "sorted_keys", "children", "num_leaves")
+    __slots__ = ("typ", "sorted_keys", "children", "num_leaves", "aux_data")
 
     def __init__(
         self,
@@ -27,35 +27,13 @@ class _TreeDef:
         sorted_keys: Optional[Tuple[str, ...]],
         children: Tuple["_TreeDef", ...],
         num_leaves: int,
+        aux_data: Any = None,
     ) -> None:
         self.typ = typ
-        self.sorted_keys = sorted_keys  # non-None only for dict
+        self.sorted_keys = sorted_keys  # non-None only for dict like
         self.children = children
         self.num_leaves = num_leaves
-
-    def unflatten(self, leaves: List[Any]) -> Any:
-        if self.typ is _LEAF:
-            if not leaves:
-                raise ValueError(
-                    "Not enough leaves to unflatten. Expected at least 1, got 0."
-                )
-            return leaves.pop(0)
-        if self.typ is dict:
-            if self.sorted_keys is None:
-                raise ValueError("sorted_keys required for dict treedef")
-            return {
-                k: child.unflatten(leaves)
-                for k, child in zip(self.sorted_keys, self.children)
-            }
-        if self.typ is _NONE_TYPE:
-            return None
-        if issubclass(self.typ, tuple):
-            result = tuple(child.unflatten(leaves) for child in self.children)
-            if self.typ is not tuple:
-                return self.typ(*result)
-            return result
-        # list
-        return [child.unflatten(leaves) for child in self.children]
+        self.aux_data = aux_data  # only used by defaultdict (factory)
 
 
 class _LeafSentinel:
@@ -84,21 +62,16 @@ def _is_leaf(obj: Any) -> bool:
     return True
 
 
-def _meta_type(obj: Any) -> type:
-    """Return the structural type tag for *obj* (tuple vs namedtuple vs ...)."""
-    if isinstance(obj, tuple) and hasattr(type(obj), "_fields"):
-        return type(obj)
-    return type(obj)
-
-
 def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], _TreeDef]:
     """
     Pure Python tree flattening with JAX-compatible semantics.
 
-    Key differences from a naïve implementation:
+    Key behaviors:
     * ``None`` is an empty pytree (0 leaves), not a leaf.
-    * ``dict`` keys are iterated in **sorted** order so that leaves are
-      deterministic regardless of insertion order.
+    * ``dict`` and ``defaultdict`` keys are iterated in **sorted** order
+      for deterministic leaf ordering.  ``defaultdict`` preserves the
+      ``default_factory`` for round-trip.
+    * ``OrderedDict`` keys are iterated in **insertion** order.
     * ``namedtuple`` is tracked as a separate type from plain ``tuple``.
     """
     if pytree is None:
@@ -107,56 +80,108 @@ def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], _TreeDef]:
         return [pytree], _TreeDef(_LEAF, None, (), 1)
     leaves: List[Any] = []
     if isinstance(pytree, dict):
-        sorted_keys = tuple(sorted(pytree.keys()))
+        actual_type = type(pytree)
+        if actual_type is OrderedDict:
+            # OrderedDict: preserve insertion order (JAX semantics)
+            keys = tuple(pytree.keys())
+            aux_data = None
+        else:
+            # dict and defaultdict: sorted keys for determinism
+            keys = tuple(sorted(pytree.keys()))
+            aux_data = pytree.default_factory if actual_type is defaultdict else None
         children = []
-        for k in sorted_keys:
+        for k in keys:
             child_leaves, child_td = _pure_tree_flatten(pytree[k])
             leaves.extend(child_leaves)
             children.append(child_td)
-        return leaves, _TreeDef(dict, sorted_keys, tuple(children), len(leaves))
+        return leaves, _TreeDef(
+            actual_type, keys, tuple(children), len(leaves), aux_data
+        )
     # list, tuple, namedtuple
     children = []
     for v in pytree:
         child_leaves, child_td = _pure_tree_flatten(v)
         leaves.extend(child_leaves)
         children.append(child_td)
-    return leaves, _TreeDef(_meta_type(pytree), None, tuple(children), len(leaves))
+    return leaves, _TreeDef(type(pytree), None, tuple(children), len(leaves))
+
+
+def _unflatten_from_iter(treedef: _TreeDef, leaf_iter: Iterator[Any]) -> Any:
+    """Recursively rebuild one node, consuming leaves from *leaf_iter*."""
+    if treedef.typ is _LEAF:
+        return next(leaf_iter)
+    if issubclass(treedef.typ, dict):
+        if treedef.sorted_keys is None:
+            raise ValueError("sorted_keys required for dict treedef")
+        pairs = [
+            (k, _unflatten_from_iter(child, leaf_iter))
+            for k, child in zip(treedef.sorted_keys, treedef.children)
+        ]
+        if treedef.typ is defaultdict:
+            return defaultdict(treedef.aux_data, pairs)
+        if treedef.typ is OrderedDict:
+            return OrderedDict(pairs)
+        return dict(pairs)
+    if treedef.typ is _NONE_TYPE:
+        return None
+    if issubclass(treedef.typ, tuple):
+        result = tuple(
+            _unflatten_from_iter(child, leaf_iter) for child in treedef.children
+        )
+        if treedef.typ is not tuple:
+            return treedef.typ(*result)
+        return result
+    # list
+    return [_unflatten_from_iter(child, leaf_iter) for child in treedef.children]
 
 
 def _pure_tree_unflatten(treedef: _TreeDef, leaves: List[Any]) -> Any:
+    """Rebuild a pytree from *treedef* and *leaves*.
+
+    Uses the :class:`_TreeDef` produced by :func:`_pure_tree_flatten`.
+    The input *leaves* list is **not** mutated; a :class:`ValueError` is
+    raised when the number of leaves does not match the structure
+    recorded in *treedef* (either too few or too many).
     """
-    Pure Python tree unflattening using a :class:`_TreeDef` produced by
-    :func:`_pure_tree_flatten`.  **Copies** *leaves* so that the original
-    list is not mutated.  Raises :class:`ValueError` when the number of
-    leaves does not match *treedef*.
-    """
-    leaves_copy = list(leaves)
-    result = treedef.unflatten(leaves_copy)
-    if leaves_copy:
+    leaf_iter = iter(leaves)
+    try:
+        result = _unflatten_from_iter(treedef, leaf_iter)
+    except StopIteration:
+        raise ValueError(
+            f"Not enough leaves for treedef: expected {treedef.num_leaves}, "
+            f"got fewer."
+        ) from None
+    # Check for leftover leaves
+    rest = list(leaf_iter)
+    if rest:
         raise ValueError(
             f"Too many leaves for treedef: expected {treedef.num_leaves}, "
-            f"got {len(leaves)}."
+            f"got {treedef.num_leaves + len(rest)}."
         )
     return result
 
 
-def _treedefs_compatible(a: _TreeDef, b: _TreeDef) -> bool:
+def _treedefs_compatible(treedef_a: _TreeDef, treedef_b: _TreeDef) -> bool:
     """Check whether two treedefs have compatible structure for tree_map."""
-    if a.typ is not b.typ:
+    if treedef_a.typ is not treedef_b.typ:
         return False
-    if a.typ is _LEAF:
+    if treedef_a.typ is _LEAF:
         return True
-    if a.typ is _NONE_TYPE:
+    if treedef_a.typ is _NONE_TYPE:
         return True
-    if a.typ is dict:
-        if a.sorted_keys != b.sorted_keys:
+    if issubclass(treedef_a.typ, dict):
+        if treedef_a.sorted_keys != treedef_b.sorted_keys:
             return False
         return all(
-            _treedefs_compatible(ac, bc) for ac, bc in zip(a.children, b.children)
+            _treedefs_compatible(ac, bc)
+            for ac, bc in zip(treedef_a.children, treedef_b.children)
         )
-    if len(a.children) != len(b.children):
+    if len(treedef_a.children) != len(treedef_b.children):
         return False
-    return all(_treedefs_compatible(ac, bc) for ac, bc in zip(a.children, b.children))
+    return all(
+        _treedefs_compatible(ac, bc)
+        for ac, bc in zip(treedef_a.children, treedef_b.children)
+    )
 
 
 def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
@@ -174,28 +199,22 @@ def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
     if all(_is_leaf(p) for p in pytrees):
         return f(*pytrees)
 
-    # Flatten and validate structure
+    # Flatten, validate structure, and collect leaf lists in one pass
     flat_results = []
     first_treedef = None
-    first_leaves: Optional[List[Any]] = None
-    for tree in pytrees:
-        leaves, td = _pure_tree_flatten(tree)
-        if first_treedef is None:
-            first_treedef = td
-            first_leaves = leaves
-        else:
-            if not _treedefs_compatible(first_treedef, td):
-                raise ValueError(
-                    "Pytree structure mismatch: all non-leaf arguments to "
-                    "tree_map must have the same structure."
-                )
-
-    assert first_leaves is not None and first_treedef is not None
-    # Collect all leaf lists
     all_leaves: List[List[Any]] = []
     for tree in pytrees:
-        leaves, _ = _pure_tree_flatten(tree)
+        leaves, td = _pure_tree_flatten(tree)
         all_leaves.append(leaves)
+        if first_treedef is None:
+            first_treedef = td
+        elif not _treedefs_compatible(first_treedef, td):
+            raise ValueError(
+                "Pytree structure mismatch: all non-leaf arguments to "
+                "tree_map must have the same structure."
+            )
+
+    assert first_treedef is not None
 
     # Apply f to corresponding leaves
     for i in range(first_treedef.num_leaves):
@@ -1417,9 +1436,11 @@ class ExtendedBackend:
 
         For the NumPy/CuPy fallback, TensorCircuit uses a pure Python implementation
         designed to match JAX jax.tree_util semantics for supported containers:
-        None is an empty pytree, dict keys are traversed in sorted order, namedtuple
-        types are distinguished from plain tuples, and tree_map requires matching
-        tree structure.
+        None is an empty pytree, dict and defaultdict keys are traversed in sorted
+        order (OrderedDict preserves insertion order), namedtuple types are
+        distinguished from plain tuples, and tree_map requires matching tree
+        structure.  OrderedDict and defaultdict round-trip correctly with their
+        respective type, key order, and ``default_factory`` preserved.
 
         Other backends may follow their native tree utility semantics instead. In
         particular, TensorFlow tf.nest treats None as a leaf, and PyTorch

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -33,7 +33,7 @@ class _TreeDef:
         self.children = children
         self.num_leaves = num_leaves
 
-    def unflatten(self, leaves: list) -> Any:
+    def unflatten(self, leaves: List[Any]) -> Any:
         if self.typ is _LEAF:
             if not leaves:
                 raise ValueError(
@@ -41,6 +41,7 @@ class _TreeDef:
                 )
             return leaves.pop(0)
         if self.typ is dict:
+            assert self.sorted_keys is not None
             return {
                 k: child.unflatten(leaves)
                 for k, child in zip(self.sorted_keys, self.children)

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -17,7 +17,9 @@ Tensor = Any
 
 
 class _TreeDef:
-    """A JAX-compatible treedef that records pytree structure for unflattening."""
+    """
+    A JAX-compatible treedef that records pytree structure for unflattening.
+    """
 
     __slots__ = ("typ", "sorted_keys", "children", "num_leaves", "aux_data")
 
@@ -29,15 +31,33 @@ class _TreeDef:
         num_leaves: int,
         aux_data: Any = None,
     ) -> None:
+        """
+        Store the structure of one pytree node.
+
+        :param typ: Python type of this node (a container type, ``NoneType``
+            for an empty pytree, or :class:`_LeafSentinel` for a leaf)
+        :type typ: type
+        :param sorted_keys: keys of a dict-like node in flatten order, else ``None``
+        :type sorted_keys: Optional[Tuple[str, ...]]
+        :param children: the :class:`_TreeDef` of each child node
+        :type children: Tuple["_TreeDef", ...]
+        :param num_leaves: total number of leaves contained in this subtree
+        :type num_leaves: int
+        :param aux_data: per-type payload such as a ``defaultdict`` factory,
+            defaults to ``None``
+        :type aux_data: Any
+        """
         self.typ = typ
-        self.sorted_keys = sorted_keys  # non-None only for dict like
+        self.sorted_keys = sorted_keys
         self.children = children
         self.num_leaves = num_leaves
-        self.aux_data = aux_data  # only used by defaultdict (factory)
+        self.aux_data = aux_data
 
 
 class _LeafSentinel:
-    """Sentinel type so that ``_TreeDef`` can represent a leaf node."""
+    """
+    Sentinel type so that :class:`_TreeDef` can represent a leaf node.
+    """
 
     pass
 
@@ -47,17 +67,32 @@ _NONE_TYPE = type(None)
 
 
 def _is_leaf(obj: Any) -> bool:
-    """Check whether *obj* is a leaf managed by the pure-pytree machinery.
+    """
+    Check whether *obj* is a leaf managed by the pure-pytree machinery.
 
-    Everything that is not a recognised pytree container (dict, list, tuple,
-    namedtuple, or ``None``) is a leaf.  This deliberately matches JAX
-    semantics for the types supported here.
+    Uses **exact** type matching, mirroring JAX ``tree_util``: only the
+    built-in container types (``dict``, ``OrderedDict``, ``defaultdict``,
+    ``list``, ``tuple``) and ``namedtuple`` classes are traversed.  Arbitrary
+    subclasses (e.g. ``class MyDict(dict)``) are **leaves** — in JAX a
+    subclass must be explicitly registered as a pytree node to be traversed,
+    so without registration the whole instance is a single leaf.
+
+    :param obj: any Python object to classify
+    :type obj: Any
+    :return: ``False`` for recognised containers and ``None``, ``True`` otherwise
+    :rtype: bool
     """
     if obj is None:
         return False
-    if isinstance(obj, dict):
+    t = type(obj)
+    if t is dict or t is OrderedDict or t is defaultdict:
         return False
-    if isinstance(obj, (list, tuple)):
+    if t is list or t is tuple:
+        return False
+    # ``namedtuple`` (and its subclasses) are tuple subclasses carrying
+    # ``_fields``; keep them as containers while plain tuple subclasses
+    # such as ``class MyTuple(tuple)`` remain leaves.
+    if isinstance(obj, tuple) and hasattr(obj, "_fields"):
         return False
     return True
 
@@ -67,12 +102,18 @@ def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], _TreeDef]:
     Pure Python tree flattening with JAX-compatible semantics.
 
     Key behaviors:
+
     * ``None`` is an empty pytree (0 leaves), not a leaf.
     * ``dict`` and ``defaultdict`` keys are iterated in **sorted** order
       for deterministic leaf ordering.  ``defaultdict`` preserves the
       ``default_factory`` for round-trip.
     * ``OrderedDict`` keys are iterated in **insertion** order.
     * ``namedtuple`` is tracked as a separate type from plain ``tuple``.
+
+    :param pytree: the Python structure to flatten
+    :type pytree: Any
+    :return: the flat list of leaves and the :class:`_TreeDef` describing the structure
+    :rtype: Tuple[List[Any], _TreeDef]
     """
     if pytree is None:
         return [], _TreeDef(_NONE_TYPE, None, (), 0)
@@ -88,7 +129,9 @@ def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], _TreeDef]:
         else:
             # dict and defaultdict: sorted keys for determinism
             keys = tuple(sorted(pytree.keys()))
-            aux_data = pytree.default_factory if actual_type is defaultdict else None
+            aux_data = (
+                pytree.default_factory if isinstance(pytree, defaultdict) else None
+            )
         children = []
         for k in keys:
             child_leaves, child_td = _pure_tree_flatten(pytree[k])
@@ -107,7 +150,16 @@ def _pure_tree_flatten(pytree: Any) -> Tuple[List[Any], _TreeDef]:
 
 
 def _unflatten_from_iter(treedef: _TreeDef, leaf_iter: Iterator[Any]) -> Any:
-    """Recursively rebuild one node, consuming leaves from *leaf_iter*."""
+    """
+    Recursively rebuild one node, consuming leaves from *leaf_iter*.
+
+    :param treedef: the structure to rebuild
+    :type treedef: _TreeDef
+    :param leaf_iter: iterator over leaves, consumed left to right
+    :type leaf_iter: Iterator[Any]
+    :return: the rebuilt pytree node
+    :rtype: Any
+    """
     if treedef.typ is _LEAF:
         return next(leaf_iter)
     if issubclass(treedef.typ, dict):
@@ -136,12 +188,21 @@ def _unflatten_from_iter(treedef: _TreeDef, leaf_iter: Iterator[Any]) -> Any:
 
 
 def _pure_tree_unflatten(treedef: _TreeDef, leaves: List[Any]) -> Any:
-    """Rebuild a pytree from *treedef* and *leaves*.
+    """
+    Rebuild a pytree from *treedef* and *leaves*.
 
     Uses the :class:`_TreeDef` produced by :func:`_pure_tree_flatten`.
     The input *leaves* list is **not** mutated; a :class:`ValueError` is
     raised when the number of leaves does not match the structure
     recorded in *treedef* (either too few or too many).
+
+    :param treedef: the structure describing the target pytree
+    :type treedef: _TreeDef
+    :param leaves: the flat leaves to repack; not mutated
+    :type leaves: List[Any]
+    :return: the rebuilt pytree
+    :rtype: Any
+    :raises ValueError: if the number of leaves does not match *treedef*
     """
     leaf_iter = iter(leaves)
     try:
@@ -162,7 +223,16 @@ def _pure_tree_unflatten(treedef: _TreeDef, leaves: List[Any]) -> Any:
 
 
 def _treedefs_compatible(treedef_a: _TreeDef, treedef_b: _TreeDef) -> bool:
-    """Check whether two treedefs have compatible structure for tree_map."""
+    """
+    Check whether two treedefs have compatible structure for ``tree_map``.
+
+    :param treedef_a: the first treedef to compare
+    :type treedef_a: _TreeDef
+    :param treedef_b: the second treedef to compare
+    :type treedef_b: _TreeDef
+    :return: ``True`` if both treedefs share type, key order, and nesting
+    :rtype: bool
+    """
     if treedef_a.typ is not treedef_b.typ:
         return False
     if treedef_a.typ is _LEAF:
@@ -191,6 +261,14 @@ def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
     Applies *f* element-wise to corresponding leaves.  All non-leaf
     arguments must share the **same** pytree structure (type, key order,
     and nesting); a :class:`ValueError` is raised on mismatch.
+
+    :param f: function applied to each tuple of corresponding leaves
+    :type f: Callable[..., Any]
+    :param pytrees: one or more pytrees with matching structure
+    :type pytrees: Any
+    :return: a pytree shaped like the inputs with ``f`` applied to the leaves
+    :rtype: Any
+    :raises ValueError: if the non-leaf arguments have mismatched structure
     """
     if not pytrees:
         raise TypeError("_pure_tree_map requires at least one pytree argument")
@@ -199,7 +277,6 @@ def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
     if all(_is_leaf(p) for p in pytrees):
         return f(*pytrees)
 
-    # Flatten, validate structure, and collect leaf lists in one pass
     flat_results = []
     first_treedef = None
     all_leaves: List[List[Any]] = []
@@ -216,9 +293,9 @@ def _pure_tree_map(f: Callable[..., Any], *pytrees: Any) -> Any:
 
     assert first_treedef is not None
 
-    # Apply f to corresponding leaves
     for i in range(first_treedef.num_leaves):
-        flat_results.append(f(*(ls[i] for ls in all_leaves)))
+        corresponding_leaves = [leaves[i] for leaves in all_leaves]
+        flat_results.append(f(*corresponding_leaves))
 
     return _pure_tree_unflatten(first_treedef, flat_results)
 

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -1413,6 +1413,27 @@ class ExtendedBackend:
         """
         Return the new tree map with multiple arg function ``f`` through pytrees.
 
+        Backend pytree utilities.
+
+        For the NumPy/CuPy fallback, TensorCircuit uses a pure Python implementation
+        designed to match JAX jax.tree_util semantics for supported containers:
+        None is an empty pytree, dict keys are traversed in sorted order, namedtuple
+        types are distinguished from plain tuples, and tree_map requires matching
+        tree structure.
+
+        Other backends may follow their native tree utility semantics instead. In
+        particular, TensorFlow tf.nest treats None as a leaf, and PyTorch
+        torch.utils._pytree preserves dict insertion order rather than JAX's sorted
+        dict-key order. Therefore corner cases involving None, dict insertion order,
+        or mixed namedtuple/tuple structures may differ across backends.
+
+        Example:
+            JAX/NumPy-style mapping over ``{"b": 2, "a": 1}`` and ``{"a": 10, "b": 20}``
+            pairs leaves by sorted keys, yielding ``{"a": 11, "b": 22}``.
+
+            PyTorch-native flattening may pair leaves by insertion order, which can
+            yield backend-specific results for the same inputs.
+
         :param f: The function
         :type f: Callable[..., Any]
         :param pytrees: inputs as any python structure

--- a/tensorcircuit/backends/abstract_backend.py
+++ b/tensorcircuit/backends/abstract_backend.py
@@ -242,6 +242,8 @@ def _treedefs_compatible(treedef_a: _TreeDef, treedef_b: _TreeDef) -> bool:
     if issubclass(treedef_a.typ, dict):
         if treedef_a.sorted_keys != treedef_b.sorted_keys:
             return False
+        if treedef_a.aux_data != treedef_b.aux_data:
+            return False
         return all(
             _treedefs_compatible(ac, bc)
             for ac, bc in zip(treedef_a.children, treedef_b.children)

--- a/tensorcircuit/backends/jax_backend.py
+++ b/tensorcircuit/backends/jax_backend.py
@@ -386,6 +386,7 @@ class JaxBackend(jax_backend.JaxBackend, ExtendedBackend):  # type: ignore
             jax_dtype = getattr(jnp, dtype)
         else:
             jax_dtype = dtype
+        a = jnp.asarray(a)
         if jnp.iscomplexobj(a) and not jnp.issubdtype(jax_dtype, jnp.complexfloating):
             a = jnp.real(a)
         return a.astype(jax_dtype)

--- a/tensorcircuit/backends/numpy_backend.py
+++ b/tensorcircuit/backends/numpy_backend.py
@@ -293,6 +293,7 @@ class NumpyBackend(numpy_backend.NumPyBackend, ExtendedBackend):  # type: ignore
                 np_dtype = getattr(np, dtype)
         else:
             np_dtype = dtype
+        a = np.asarray(a)
         if np.iscomplexobj(a) and not np.issubdtype(np_dtype, np.complexfloating):
             a = np.real(a)
         return a.astype(np_dtype)

--- a/tensorcircuit/backends/pytorch_backend.py
+++ b/tensorcircuit/backends/pytorch_backend.py
@@ -585,6 +585,7 @@ class PyTorchBackend(pytorch_backend.PyTorchBackend, ExtendedBackend):  # type: 
             torch_dtype = getattr(torchlib, dtype)
         else:
             torch_dtype = dtype
+        a = torchlib.as_tensor(a)
         if torchlib.is_complex(a) and not getattr(torch_dtype, "is_complex", False):
             a = torchlib.real(a)
         return a.to(torch_dtype)

--- a/tensorcircuit/backends/tensorflow_backend.py
+++ b/tensorcircuit/backends/tensorflow_backend.py
@@ -1200,5 +1200,16 @@ class TensorFlowBackend(tensorflow_backend.TensorFlowBackend, ExtendedBackend): 
 
     optimizer = keras_optimizer
 
+    def tree_map(self: Any, f: Callable[..., Any], *pytrees: Any) -> Any:
+        return tf.nest.map_structure(f, *pytrees)
+
+    def tree_flatten(self: Any, pytree: Any) -> Tuple[Any, Any]:
+        leaves = tf.nest.flatten(pytree)
+        treedef = pytree
+        return leaves, treedef
+
+    def tree_unflatten(self: Any, treedef: Any, leaves: Any) -> Any:
+        return tf.nest.pack_sequence_as(treedef, leaves)
+
     def expand_dims(self, a: Tensor, axis: int) -> Tensor:
         return tf.expand_dims(a, axis)

--- a/tensorcircuit/gates.py
+++ b/tensorcircuit/gates.py
@@ -1041,11 +1041,9 @@ def rzm_gate(theta: float, n: int, dim: int = 2, name: str = "rzm") -> Operator:
     if n < 2:
         raise ValueError("Gate requires at least 2 qubits.")
     if dim != 2:
-        # TODO: support general dimensions
         raise ValueError("rzm gate only supports dim=2 at the moment.")
 
     theta_t = backend.cast(backend.convert_to_tensor(theta), dtype=dtypestr)
-
     i_tensor = backend.cast(backend.convert_to_tensor(1j), dtypestr)
     c = backend.cast(backend.cos(theta_t / 2.0), dtypestr)
     s = backend.cast(backend.sin(theta_t / 2.0), dtypestr)
@@ -1055,14 +1053,14 @@ def rzm_gate(theta: float, n: int, dim: int = 2, name: str = "rzm") -> Operator:
         (dim, 2),
     )
 
-    mk_np = np.zeros((2, dim, 2), dtype=np.complex128)
+    mk_np = np.zeros((2, dim, 2), dtype=npdtype)
     mk_np[0, 0, 0] = 1.0
     mk_np[0, 1, 0] = 1.0
     mk_np[1, 0, 1] = 1.0
     mk_np[1, 1, 1] = -1.0
     mk = backend.cast(backend.convert_to_tensor(mk_np), dtype=dtypestr)
 
-    mn_np = np.zeros((2, dim), dtype=np.complex128)
+    mn_np = np.zeros((2, dim), dtype=npdtype)
     mn_np[0, 0] = 1.0
     mn_np[0, 1] = 1.0
     mn_np[1, 0] = 1.0
@@ -1100,22 +1098,21 @@ def cmz_gate(n: int, dim: int = 2, name: str = "cmz") -> Operator:
     if n < 2:
         raise ValueError("Gate requires at least 2 qubits.")
     if dim != 2:
-        # TODO: support general dimensions
         raise ValueError("cmz gate only supports dim=2 at the moment.")
 
-    m1_np = np.zeros((dim, 2), dtype=np.complex128)
+    m1_np = np.zeros((dim, 2), dtype=npdtype)
     m1_np[0, 0] = 1.0
     m1_np[1, 0] = 1.0
     m1_np[1, 1] = -2.0
     m1 = backend.cast(backend.convert_to_tensor(m1_np), dtype=dtypestr)
 
-    mk_np = np.zeros((2, dim, 2), dtype=np.complex128)
+    mk_np = np.zeros((2, dim, 2), dtype=npdtype)
     mk_np[0, 0, 0] = 1.0
     mk_np[0, 1, 0] = 1.0
     mk_np[1, 1, 1] = 1.0
     mk = backend.cast(backend.convert_to_tensor(mk_np), dtype=dtypestr)
 
-    mn_np = np.zeros((2, dim), dtype=np.complex128)
+    mn_np = np.zeros((2, dim), dtype=npdtype)
     mn_np[0, 0] = 1.0
     mn_np[0, 1] = 1.0
     mn_np[1, 1] = 1.0

--- a/tensorcircuit/translation.py
+++ b/tensorcircuit/translation.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
+from .cons import rdtypestr
+
 logger = logging.getLogger(__name__)
 
 
@@ -327,7 +329,7 @@ def qir2qiskit(
         elif gate_name in ["exp", "exp1"]:
             unitary = backend.numpy(backend.convert_to_tensor(parameters["unitary"]))
             theta = backend.numpy(backend.convert_to_tensor(parameters["theta"]))
-            theta = np.array(np.real(theta)).astype(np.float64)
+            theta = np.array(np.real(theta)).astype(getattr(np, rdtypestr))
             # cast theta to real, since qiskit only support unitary.
             # Error can be presented if theta is actually complex in this procedure.
             exp_op = qi.Operator(unitary)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@ import sys
 import os
 import pytest
 
+# NOTE: If Intel OpenMP abort occurs on Windows (PyTorch + scipy DLL conflict),
+# set KMP_DUPLICATE_LIB_OK=TRUE in the test runner environment, e.g.:
+#   $env:KMP_DUPLICATE_LIB_OK = "TRUE"
+
 thisfile = os.path.abspath(__file__)
 modulepath = os.path.dirname(os.path.dirname(thisfile))
 

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -15,7 +15,7 @@ semantics, covering:
 
 import sys
 import os
-from collections import namedtuple
+from collections import namedtuple, OrderedDict, defaultdict
 
 import numpy as np
 import pytest
@@ -52,7 +52,6 @@ class TestFlattenBasic:
         assert td.typ is _LEAF
 
     def test_flatten_single_string(self):
-        # strings are leaves (not treated as containers)
         leaves, _ = _pure_tree_flatten("hello")
         assert leaves == ["hello"]
 
@@ -83,7 +82,6 @@ class TestFlattenBasic:
 
     def test_flatten_flat_dict(self):
         leaves, td = _pure_tree_flatten({"x": 1, "y": 2})
-        # keys should be sorted → [1, 2]
         assert leaves == [1, 2]
         assert td.num_leaves == 2
         assert td.sorted_keys == ("x", "y")
@@ -113,7 +111,6 @@ class TestFlattenDictKeyOrder:
     def test_unsorted_keys(self):
         tree = {"b": 2, "a": 1}
         leaves, td = _pure_tree_flatten(tree)
-        # JAX sorts dict keys; leaves should follow sorted order
         assert leaves == [1, 2]
         assert td.sorted_keys == ("a", "b")
 
@@ -121,6 +118,43 @@ class TestFlattenDictKeyOrder:
         tree = {"2": "x", "1": "y", "3": "z"}
         leaves, _ = _pure_tree_flatten(tree)
         assert leaves == ["y", "x", "z"]
+
+
+class TestFlattenOrderedDict:
+    """OrderedDict preserves insertion order (not sorted like dict)."""
+
+    def test_orderedict_preserves_insertion_order(self):
+        od = OrderedDict([("c", 3), ("a", 1), ("b", 2)])
+        leaves, td = _pure_tree_flatten(od)
+        # Insertion order, not sorted
+        assert leaves == [3, 1, 2]
+        assert td.sorted_keys == ("c", "a", "b")
+
+    def test_orderedict_type_recorded(self):
+        od = OrderedDict([("a", 1)])
+        _, td = _pure_tree_flatten(od)
+        assert td.typ is OrderedDict
+
+
+class TestFlattenDefaultDict:
+    """defaultdict uses sorted keys and records default_factory."""
+
+    def test_defaultdict_sorted_keys(self):
+        dd = defaultdict(int, {"b": 2, "a": 1})
+        leaves, td = _pure_tree_flatten(dd)
+        assert leaves == [1, 2]
+        assert td.sorted_keys == ("a", "b")
+
+    def test_defaultdict_type_recorded(self):
+        dd = defaultdict(list, {"a": [1]})
+        _, td = _pure_tree_flatten(dd)
+        assert td.typ is defaultdict
+        assert td.aux_data is list
+
+    def test_defaultdict_none_factory(self):
+        dd = defaultdict(None, {"a": 1})
+        _, td = _pure_tree_flatten(dd)
+        assert td.aux_data is None
 
 
 class TestFlattenNamedTuple:
@@ -148,7 +182,6 @@ class TestFlattenNested:
     def test_nested_list_dict(self):
         tree = {"a": [1, 2], "b": (3, {"c": 4})}
         leaves, td = _pure_tree_flatten(tree)
-        # sorted keys: a → [1,2], b → (3, {"c": 4})
         assert leaves == [1, 2, 3, 4]
         assert td.num_leaves == 4
 
@@ -161,7 +194,6 @@ class TestFlattenNested:
     def test_mixed_none_and_values(self):
         tree = {"a": None, "b": [None, 1], "c": 3}
         leaves, _ = _pure_tree_flatten(tree)
-        # sorted keys: a→None(0 leaves), b→[None, 1] → [1], c→3
         assert leaves == [1, 3]
 
 
@@ -213,6 +245,43 @@ class TestUnflattenBasic:
         assert leaves == original_leaves
 
 
+class TestUnflattenOrderedDict:
+    """OrderedDict round-trips and preserves insertion order."""
+
+    def test_roundtrip_ordereddict(self):
+        od = OrderedDict([("c", 3), ("a", 1), ("b", 2)])
+        leaves, td = _pure_tree_flatten(od)
+        result = _pure_tree_unflatten(td, leaves)
+        assert isinstance(result, OrderedDict)
+        assert list(result.keys()) == ["c", "a", "b"]
+        assert result == {"c": 3, "a": 1, "b": 2}
+
+    def test_ordereddict_not_plain_dict(self):
+        od = OrderedDict([("a", 1)])
+        _, td = _pure_tree_flatten(od)
+        result = _pure_tree_unflatten(td, [10])
+        assert type(result) is OrderedDict
+
+
+class TestUnflattenDefaultDict:
+    """defaultdict round-trips and preserves default_factory."""
+
+    def test_roundtrip_defaultdict(self):
+        dd = defaultdict(list, {"a": [1, 2], "b": [3]})
+        leaves, td = _pure_tree_flatten(dd)
+        result = _pure_tree_unflatten(td, leaves)
+        assert isinstance(result, defaultdict)
+        assert result.default_factory is list
+        assert result == {"a": [1, 2], "b": [3]}
+
+    def test_roundtrip_defaultdict_none_factory(self):
+        dd = defaultdict(None, {"a": 1})
+        leaves, td = _pure_tree_flatten(dd)
+        result = _pure_tree_unflatten(td, leaves)
+        assert isinstance(result, defaultdict)
+        assert result.default_factory is None
+
+
 class TestUnflattenNamedTuple:
     """namedtuple round-trips correctly."""
 
@@ -243,7 +312,6 @@ class TestUnflattenNested:
     def test_replace_values(self):
         tree = {"a": [1, 2], "b": [3]}
         leaves, td = _pure_tree_flatten(tree)
-        # Replace with doubled values
         result = _pure_tree_unflatten(td, [x * 2 for x in leaves])
         assert result == {"a": [2, 4], "b": [6]}
 
@@ -301,6 +369,20 @@ class TestTreeMapBasic:
         result = _pure_tree_map(lambda x: x + 10, tree)
         assert result == {"a": [11, 12], "b": (13,)}
 
+    def test_map_preserves_orderedict_type(self):
+        od = OrderedDict([("c", 1), ("a", 2)])
+        result = _pure_tree_map(lambda x: x * 10, od)
+        assert isinstance(result, OrderedDict)
+        assert list(result.keys()) == ["c", "a"]
+        assert result == {"c": 10, "a": 20}
+
+    def test_map_preserves_defaultdict_type(self):
+        dd = defaultdict(int, {"a": 1, "b": 2})
+        result = _pure_tree_map(lambda x: x * 10, dd)
+        assert isinstance(result, defaultdict)
+        assert result.default_factory is int
+        assert result == {"a": 10, "b": 20}
+
 
 class TestTreeMapMultiArg:
     """Mapping with multiple tree arguments."""
@@ -330,17 +412,14 @@ class TestTreeMapStructureMismatch:
     """JAX raises ValueError on structure mismatch."""
 
     def test_scalar_broadcast_is_rejected(self):
-        """Passing a scalar where a container is expected should fail."""
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: (x, y), {"a": [1, 2]}, 9)
 
     def test_none_vs_scalar_is_rejected(self):
-        """``None`` is an empty pytree; mapping it with a scalar leaf mismatches."""
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: (x, y), None, 5)
 
     def test_namedtuple_vs_tuple_is_rejected(self):
-        """namedtuple and plain tuple are different types."""
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: (x, y), Point(1, 2), (3, 4))
 
@@ -455,27 +534,22 @@ class TestFlattenCornerCases:
         assert result == [[[[[42]]]]]
 
     def test_mixed_types_in_list(self):
-        """Container types become leaves when inside a list."""
         tree = [1, "hello", 3.14, True]
         leaves, _ = _pure_tree_flatten(tree)
         assert leaves == [1, "hello", 3.14, True]
 
     def test_dict_with_integer_keys(self):
-        """Integer dict keys should be sorted numerically."""
         tree = {2: "b", 1: "a", 3: "c"}
         leaves, _ = _pure_tree_flatten(tree)
         assert leaves == ["a", "b", "c"]
 
     def test_frozenset_is_leaf(self):
-        """frozenset is not a supported container; it should be a leaf."""
         fs = frozenset([1, 2, 3])
         leaves, td = _pure_tree_flatten(fs)
         assert leaves == [fs]
         assert td.typ is _LEAF
 
     def test_dict_subclass_is_container(self):
-        """Custom dict subclass is treated as a container (via isinstance)."""
-
         class MyDict(dict):
             pass
 
@@ -485,8 +559,6 @@ class TestFlattenCornerCases:
         assert td.num_leaves == 1
 
     def test_list_subclass_is_container(self):
-        """Custom list subclass is treated as a container (via isinstance)."""
-
         class MyList(list):
             pass
 
@@ -500,7 +572,6 @@ class TestUnflattenCornerCases:
     """Corner cases for unflatten."""
 
     def test_treedef_is_reusable(self):
-        """The same _TreeDef should be usable multiple times."""
         _, td = _pure_tree_flatten({"a": 1, "b": 2})
         r1 = _pure_tree_unflatten(td, [10, 20])
         r2 = _pure_tree_unflatten(td, [30, 40])
@@ -511,7 +582,6 @@ class TestUnflattenCornerCases:
         "tree", [None, [], {}], ids=["none", "empty_list", "empty_dict"]
     )
     def test_unflatten_empty_with_extra_leaves_raises(self, tree):
-        """0-leaf structures should reject any non-empty leaf list."""
         _, td = _pure_tree_flatten(tree)
         with pytest.raises(ValueError):
             _pure_tree_unflatten(td, [1])
@@ -524,12 +594,9 @@ class TestUnflattenCornerCases:
         assert result == tree
 
     def test_unflatten_dict_key_to_sorted_leaf_mapping(self):
-        """unflatten maps leaves in sorted-key order back to dict keys."""
         tree = {"z": 1, "a": 2, "m": 3}
         leaves, td = _pure_tree_flatten(tree)
-        # leaves are in sorted-key order: a→2, m→3, z→1
         assert leaves == [2, 3, 1]
-        # unflatten also consumes leaves in sorted-key order
         result = _pure_tree_unflatten(td, [20, 30, 40])
         assert result == {"z": 40, "a": 20, "m": 30}
 
@@ -546,31 +613,24 @@ class TestTreeMapCornerCases:
         assert result == 7
 
     def test_nested_structure_mismatch_deep(self):
-        """Mismatch at a deeply nested level should be detected."""
         t1 = {"a": {"b": [1, 2]}}
-        t2 = {"a": {"b": [1, 2, 3]}}  # deeper mismatch
+        t2 = {"a": {"b": [1, 2, 3]}}
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: x + y, t1, t2)
 
     def test_nested_type_mismatch(self):
-        """Type mismatch at a nested level."""
         t1 = {"a": [1, 2]}
-        t2 = {"a": (1, 2)}  # list vs tuple at nested level
+        t2 = {"a": (1, 2)}
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: x + y, t1, t2)
 
     def test_different_namedtuple_types_mismatch(self):
-        """Two different namedtuple types should not match."""
         RGB = namedtuple("RGB", ["r", "g"])
-        # Point and RGB are different namedtuples with same field count
-        # _treedefs_compatible checks `a.typ is not b.typ` → mismatch
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: x + y, Point(1, 2), RGB(10, 20))
 
     def test_different_arities_namedtuple_mismatch(self):
-        """namedtuples with different field counts should mismatch."""
         RGB3 = namedtuple("RGB3", ["r", "g", "b"])
-        # Point has 2 fields, RGB3 has 3 → length mismatch
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: x + y, Point(1, 2), RGB3(10, 20, 30))
 
@@ -585,7 +645,6 @@ class TestTreeMapCornerCases:
             assert result == tree
 
     def test_map_preserves_namedtuple_type(self):
-        """namedtuple type must be preserved (not demoted to plain tuple)."""
         result = _pure_tree_map(lambda x: x * 2, Point(3, 4))
         assert isinstance(result, Point)
         assert result == Point(6, 8)
@@ -597,8 +656,6 @@ class TestTreeMapCornerCases:
         assert result == {"b": 22, "a": 11}
 
     def test_map_propagates_leaf_exception(self):
-        """Exception raised by f should propagate with context."""
-
         def boom(x):
             raise RuntimeError("leaf error")
 
@@ -628,7 +685,6 @@ class TestJAXComparisonTreeMap:
         assert py_result == jax_result
 
     def test_tree_map_rejects_mismatch_like_jax(self):
-        # dict vs scalar: different input from the pure test
         with pytest.raises(ValueError):
             tree_util.tree_map(lambda x, y: (x, y), {"x": [3, 4]}, "bad")
         with pytest.raises(ValueError):
@@ -663,7 +719,7 @@ class TestJAXComparisonEmptyStructures:
 
 
 # ---------------------------------------------------------------------------
-# JAX comparison tests (requires jax)
+# JAX comparison tests
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -1,0 +1,747 @@
+"""
+Tests for ``_pure_tree_flatten``, ``_pure_tree_unflatten``, and ``_pure_tree_map``
+in ``tensorcircuit.backends.abstract_backend``.
+
+All tests compare our pure-Python pytree utilities against JAX ``tree_util``
+semantics, covering:
+  - dict key ordering (sorted vs insertion order)
+  - ``None`` as empty pytree (0 leaves)
+  - ``namedtuple`` vs plain ``tuple`` type distinction
+  - strict structure matching in ``tree_map`` (no scalar broadcast)
+  - leaf-count validation in ``unflatten`` (ValueError on mismatch)
+  - round-trip ``flatten → unflatten``
+  - complex nested structures
+"""
+
+# pylint: disable=missing-class-docstring, missing-function-docstring
+
+import sys
+import os
+from collections import namedtuple
+
+import pytest
+
+thisfile = os.path.abspath(__file__)
+modulepath = os.path.dirname(os.path.dirname(thisfile))
+sys.path.insert(0, modulepath)
+
+from tensorcircuit.backends.abstract_backend import (
+    _pure_tree_flatten,
+    _pure_tree_map,
+    _pure_tree_unflatten,
+    _LEAF,
+    _NONE_TYPE,
+)
+
+Point = namedtuple("Point", ["x", "y"])
+
+
+# ---------------------------------------------------------------------------
+# _pure_tree_flatten
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenBasic:
+    """Basic flattening behaviours."""
+
+    def test_flatten_single_int(self):
+        leaves, td = _pure_tree_flatten(42)
+        assert leaves == [42]
+        assert td.typ is _LEAF
+
+    def test_flatten_single_string(self):
+        # strings are leaves (not treated as containers)
+        leaves, _ = _pure_tree_flatten("hello")
+        assert leaves == ["hello"]
+
+    def test_flatten_empty_list(self):
+        leaves, td = _pure_tree_flatten([])
+        assert leaves == []
+        assert td.num_leaves == 0
+
+    def test_flatten_empty_tuple(self):
+        leaves, td = _pure_tree_flatten(())
+        assert leaves == []
+        assert td.num_leaves == 0
+
+    def test_flatten_empty_dict(self):
+        leaves, td = _pure_tree_flatten({})
+        assert leaves == []
+        assert td.num_leaves == 0
+
+    def test_flatten_flat_list(self):
+        leaves, td = _pure_tree_flatten([1, 2, 3])
+        assert leaves == [1, 2, 3]
+        assert td.num_leaves == 3
+
+    def test_flatten_flat_tuple(self):
+        leaves, td = _pure_tree_flatten((10, 20))
+        assert leaves == [10, 20]
+        assert td.num_leaves == 2
+
+    def test_flatten_flat_dict(self):
+        leaves, td = _pure_tree_flatten({"x": 1, "y": 2})
+        # keys should be sorted → [1, 2]
+        assert leaves == [1, 2]
+        assert td.num_leaves == 2
+        assert td.sorted_keys == ("x", "y")
+
+
+class TestFlattenNone:
+    """``None`` is an empty pytree (0 leaves), not a leaf."""
+
+    def test_none_is_empty(self):
+        leaves, td = _pure_tree_flatten(None)
+        assert leaves == []
+        assert td.typ is _NONE_TYPE
+        assert td.num_leaves == 0
+
+    def test_nested_none_in_list(self):
+        leaves, _ = _pure_tree_flatten([1, None, 3])
+        assert leaves == [1, 3]
+
+    def test_nested_none_in_dict(self):
+        leaves, _ = _pure_tree_flatten({"a": 1, "b": None})
+        assert leaves == [1]
+
+
+class TestFlattenDictKeyOrder:
+    """Dict keys are iterated in sorted order for deterministic leaf order."""
+
+    def test_unsorted_keys(self):
+        tree = {"b": 2, "a": 1}
+        leaves, td = _pure_tree_flatten(tree)
+        # JAX sorts dict keys; leaves should follow sorted order
+        assert leaves == [1, 2]
+        assert td.sorted_keys == ("a", "b")
+
+    def test_numeric_string_keys(self):
+        tree = {"2": "x", "1": "y", "3": "z"}
+        leaves, _ = _pure_tree_flatten(tree)
+        assert leaves == ["y", "x", "z"]
+
+
+class TestFlattenNamedTuple:
+    """namedtuple should be a separate type from plain tuple."""
+
+    def test_namedtuple_preserves_type(self):
+        p = Point(1, 2)
+        leaves, td = _pure_tree_flatten(p)
+        assert leaves == [1, 2]
+        assert td.typ is Point
+        assert td.num_leaves == 2
+
+    def test_namedtuple_is_not_plain_tuple(self):
+        p = Point(1, 2)
+        _, td_p = _pure_tree_flatten(p)
+        _, td_t = _pure_tree_flatten((1, 2))
+        assert td_p.typ is Point
+        assert td_t.typ is tuple
+        assert td_p.typ is not td_t.typ
+
+
+class TestFlattenNested:
+    """Complex nested structures."""
+
+    def test_nested_list_dict(self):
+        tree = {"a": [1, 2], "b": (3, {"c": 4})}
+        leaves, td = _pure_tree_flatten(tree)
+        # sorted keys: a → [1,2], b → (3, {"c": 4})
+        assert leaves == [1, 2, 3, 4]
+        assert td.num_leaves == 4
+
+    def test_deep_nesting(self):
+        tree = {"z": {"y": {"x": [1]}}}
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [1]
+        assert td.num_leaves == 1
+
+    def test_mixed_none_and_values(self):
+        tree = {"a": None, "b": [None, 1], "c": 3}
+        leaves, _ = _pure_tree_flatten(tree)
+        # sorted keys: a→None(0 leaves), b→[None, 1] → [1], c→3
+        assert leaves == [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# _pure_tree_unflatten
+# ---------------------------------------------------------------------------
+
+
+class TestUnflattenBasic:
+    """Basic unflattening behaviours."""
+
+    def test_roundtrip_int(self):
+        leaves, td = _pure_tree_flatten(42)
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == 42
+
+    def test_roundtrip_list(self):
+        tree = [1, 2, 3]
+        leaves, td = _pure_tree_flatten(tree)
+        assert _pure_tree_unflatten(td, leaves) == [1, 2, 3]
+
+    def test_roundtrip_tuple(self):
+        tree = (10, 20)
+        leaves, td = _pure_tree_flatten(tree)
+        assert _pure_tree_unflatten(td, leaves) == (10, 20)
+
+    def test_roundtrip_dict(self):
+        tree = {"b": 2, "a": 1}
+        leaves, td = _pure_tree_flatten(tree)
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == {"b": 2, "a": 1}
+
+    def test_roundtrip_empty(self):
+        for tree in [[], (), {}]:
+            leaves, td = _pure_tree_flatten(tree)
+            result = _pure_tree_unflatten(td, leaves)
+            assert result == tree
+
+    def test_roundtrip_none(self):
+        leaves, td = _pure_tree_flatten(None)
+        result = _pure_tree_unflatten(td, leaves)
+        assert result is None
+
+    def test_does_not_mutate_input(self):
+        tree = {"a": 1, "b": [2, 3]}
+        leaves, td = _pure_tree_flatten(tree)
+        original_leaves = list(leaves)
+        _pure_tree_unflatten(td, leaves)
+        assert leaves == original_leaves
+
+
+class TestUnflattenNamedTuple:
+    """namedtuple round-trips correctly."""
+
+    def test_roundtrip_namedtuple(self):
+        p = Point(10, 20)
+        leaves, td = _pure_tree_flatten(p)
+        result = _pure_tree_unflatten(td, leaves)
+        assert isinstance(result, Point)
+        assert result == Point(10, 20)
+
+    def test_namedtuple_not_plain_tuple(self):
+        p = Point(1, 2)
+        _, td = _pure_tree_flatten(p)
+        result = _pure_tree_unflatten(td, [100, 200])
+        assert isinstance(result, Point)
+        assert result == Point(100, 200)
+
+
+class TestUnflattenNested:
+    """Nested round-trips."""
+
+    def test_nested_list_dict(self):
+        tree = {"a": [1, 2], "b": (3, {"c": 4})}
+        leaves, td = _pure_tree_flatten(tree)
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == tree
+
+    def test_replace_values(self):
+        tree = {"a": [1, 2], "b": [3]}
+        leaves, td = _pure_tree_flatten(tree)
+        # Replace with doubled values
+        result = _pure_tree_unflatten(td, [x * 2 for x in leaves])
+        assert result == {"a": [2, 4], "b": [6]}
+
+
+class TestUnflattenLeafCountValidation:
+    """Validate leaf count on unflatten (JAX raises ValueError)."""
+
+    def test_extra_leaves_raises_valueerror(self):
+        _, td = _pure_tree_flatten({"a": 1})
+        with pytest.raises(ValueError, match="Too many leaves"):
+            _pure_tree_unflatten(td, [10, 11])
+
+    def test_too_few_leaves_raises_valueerror(self):
+        _, td = _pure_tree_flatten({"a": 1, "b": 2})
+        with pytest.raises(ValueError):
+            _pure_tree_unflatten(td, [10])
+
+    def test_empty_leaves_for_nonempty_tree(self):
+        _, td = _pure_tree_flatten([1, 2])
+        with pytest.raises(ValueError):
+            _pure_tree_unflatten(td, [])
+
+    def test_correct_count_succeeds(self):
+        _, td = _pure_tree_flatten({"a": 1, "b": 2})
+        result = _pure_tree_unflatten(td, [10, 20])
+        assert result == {"a": 10, "b": 20}
+
+
+# ---------------------------------------------------------------------------
+# _pure_tree_map
+# ---------------------------------------------------------------------------
+
+
+class TestTreeMapBasic:
+    """Basic mapping behaviours."""
+
+    def test_map_over_scalar(self):
+        result = _pure_tree_map(lambda x: x + 1, 5)
+        assert result == 6
+
+    def test_map_over_list(self):
+        result = _pure_tree_map(lambda x: x * 2, [1, 2, 3])
+        assert result == [2, 4, 6]
+
+    def test_map_over_tuple(self):
+        result = _pure_tree_map(lambda x: x + 10, (1, 2))
+        assert result == (11, 12)
+
+    def test_map_over_dict(self):
+        result = _pure_tree_map(lambda x: x * 3, {"a": 1, "b": 2})
+        assert result == {"a": 3, "b": 6}
+
+    def test_map_over_none(self):
+        # None is an empty pytree; map over it returns None
+        result = _pure_tree_map(lambda x: x + 1, None)
+        assert result is None
+
+    def test_map_over_nested(self):
+        tree = {"a": [1, 2], "b": (3,)}
+        result = _pure_tree_map(lambda x: x + 10, tree)
+        assert result == {"a": [11, 12], "b": (13,)}
+
+
+class TestTreeMapMultiArg:
+    """Mapping with multiple tree arguments."""
+
+    def test_two_lists(self):
+        result = _pure_tree_map(lambda x, y: x + y, [1, 2], [10, 20])
+        assert result == [11, 22]
+
+    def test_two_dicts(self):
+        result = _pure_tree_map(
+            lambda x, y: x + y, {"a": 1, "b": 2}, {"a": 10, "b": 20}
+        )
+        assert result == {"a": 11, "b": 22}
+
+    def test_two_nested(self):
+        t1 = {"a": [1, 2], "b": [3]}
+        t2 = {"a": [10, 20], "b": [30]}
+        result = _pure_tree_map(lambda x, y: x + y, t1, t2)
+        assert result == {"a": [11, 22], "b": [33]}
+
+    def test_three_args(self):
+        result = _pure_tree_map(lambda x, y, z: x + y + z, [1], [10], [100])
+        assert result == [111]
+
+
+class TestTreeMapStructureMismatch:
+    """JAX raises ValueError on structure mismatch."""
+
+    def test_scalar_broadcast_is_rejected(self):
+        """Passing a scalar where a container is expected should fail."""
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: (x, y), {"a": [1, 2]}, 9)
+
+    def test_none_vs_scalar_is_rejected(self):
+        """``None`` is an empty pytree; mapping it with a scalar leaf mismatches."""
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: (x, y), None, 5)
+
+    def test_namedtuple_vs_tuple_is_rejected(self):
+        """namedtuple and plain tuple are different types."""
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: (x, y), Point(1, 2), (3, 4))
+
+    def test_dict_key_mismatch(self):
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: (x, y), {"a": 1}, {"b": 2})
+
+    def test_length_mismatch(self):
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: (x, y), [1, 2], [1, 2, 3])
+
+    def test_type_mismatch_dict_vs_list(self):
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: (x, y), {"a": 1}, [1])
+
+
+class TestTreeMapNoArgs:
+    """Edge case: no pytree arguments."""
+
+    def test_zero_args_raises(self):
+        with pytest.raises(TypeError):
+            _pure_tree_map(lambda: 42)
+
+
+class TestTreeMapDifferentTypes:
+    """Verify that container types are preserved."""
+
+    def test_tuple_preserved(self):
+        result = _pure_tree_map(lambda x: x + 1, (1, 2, 3))
+        assert isinstance(result, tuple)
+
+    def test_namedtuple_preserved(self):
+        result = _pure_tree_map(lambda x: x * 2, Point(3, 4))
+        assert isinstance(result, Point)
+        assert result == Point(6, 8)
+
+    def test_list_preserved(self):
+        result = _pure_tree_map(lambda x: x + 1, [1])
+        assert isinstance(result, list)
+
+    def test_dict_preserved(self):
+        result = _pure_tree_map(lambda x: x, {"k": 1})
+        assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# Integration / round-trip with backend API
+# ---------------------------------------------------------------------------
+
+
+class TestBackendIntegration:
+    """Smoke tests through the ``tc.backend`` public API."""
+
+    def test_flatten_dict_key_order_via_backend(self):
+        import tensorcircuit as tc
+
+        tc.set_backend("numpy")
+        tree = {"b": 2, "a": 1}
+        leaves, _ = tc.backend.tree_flatten(tree)
+        assert leaves == [1, 2]
+
+    def test_roundtrip_via_backend(self):
+        import tensorcircuit as tc
+
+        tc.set_backend("numpy")
+        tree = {"a": [1, 2], "b": (3, 4)}
+        leaves, td = tc.backend.tree_flatten(tree)
+        result = tc.backend.tree_unflatten(td, leaves)
+        assert result == tree
+
+    def test_tree_map_via_backend(self):
+        import numpy as np
+        import tensorcircuit as tc
+
+        tc.set_backend("numpy")
+        tree = {"a": np.ones([2]), "b": np.zeros([3])}
+        result = tc.backend.tree_map(lambda x: x + 1, tree)
+        np.testing.assert_allclose(result["a"], 2 * np.ones([2]))
+        np.testing.assert_allclose(result["b"], np.ones([3]))
+
+
+# ---------------------------------------------------------------------------
+# Additional corner cases
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenCornerCases:
+    """Edge-case leaf and container types."""
+
+    def test_float_is_leaf(self):
+        leaves, td = _pure_tree_flatten(3.14)
+        assert leaves == [3.14]
+        assert td.typ is _LEAF
+
+    def test_bool_is_leaf(self):
+        leaves, _ = _pure_tree_flatten(True)
+        assert leaves == [True]
+
+    def test_object_is_leaf(self):
+        obj = object()
+        leaves, _ = _pure_tree_flatten(obj)
+        assert leaves == [obj]
+
+    def test_single_element_tuple(self):
+        leaves, td = _pure_tree_flatten((42,))
+        assert leaves == [42]
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == (42,)
+        assert isinstance(result, tuple)
+
+    def test_single_element_list(self):
+        leaves, td = _pure_tree_flatten([99])
+        assert leaves == [99]
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == [99]
+
+    def test_list_of_none(self):
+        leaves, td = _pure_tree_flatten([None, None])
+        assert leaves == []
+        assert td.num_leaves == 0
+        result = _pure_tree_unflatten(td, [])
+        assert result == [None, None]
+
+    def test_namedtuple_with_none_fields(self):
+        p = Point(None, 1)
+        leaves, td = _pure_tree_flatten(p)
+        assert leaves == [1]
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == Point(None, 1)
+
+    def test_dict_with_empty_values(self):
+        tree = {"a": [], "b": [1]}
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [1]
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == {"a": [], "b": [1]}
+
+    def test_deeply_nested_list(self):
+        tree = [[[[[42]]]]]
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [42]
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == [[[[[42]]]]]
+
+    def test_mixed_types_in_list(self):
+        """Container types become leaves when inside a list."""
+        tree = [1, "hello", 3.14, True]
+        leaves, _ = _pure_tree_flatten(tree)
+        assert leaves == [1, "hello", 3.14, True]
+
+
+class TestUnflattenCornerCases:
+    """Corner cases for unflatten."""
+
+    def test_treedef_is_reusable(self):
+        """The same _TreeDef should be usable multiple times."""
+        _, td = _pure_tree_flatten({"a": 1, "b": 2})
+        r1 = _pure_tree_unflatten(td, [10, 20])
+        r2 = _pure_tree_unflatten(td, [30, 40])
+        assert r1 == {"a": 10, "b": 20}
+        assert r2 == {"a": 30, "b": 40}
+
+    def test_unflatten_none_with_extra_leaves_raises(self):
+        _, td = _pure_tree_flatten(None)
+        with pytest.raises(ValueError, match="Too many leaves"):
+            _pure_tree_unflatten(td, [1])
+
+    def test_unflatten_empty_list_with_extra_leaves_raises(self):
+        _, td = _pure_tree_flatten([])
+        with pytest.raises(ValueError):
+            _pure_tree_unflatten(td, [1])
+
+    def test_unflatten_empty_dict_with_extra_leaves_raises(self):
+        _, td = _pure_tree_flatten({})
+        with pytest.raises(ValueError):
+            _pure_tree_unflatten(td, [1])
+
+    def test_complex_nested_roundtrip_with_none(self):
+        tree = {"a": [None, {"b": 1}], "c": (None, [2])}
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [1, 2]
+        result = _pure_tree_unflatten(td, leaves)
+        assert result == tree
+
+    def test_unflatten_dict_key_to_sorted_leaf_mapping(self):
+        """unflatten maps leaves in sorted-key order back to dict keys."""
+        tree = {"z": 1, "a": 2, "m": 3}
+        leaves, td = _pure_tree_flatten(tree)
+        # leaves are in sorted-key order: a→2, m→3, z→1
+        assert leaves == [2, 3, 1]
+        # unflatten also consumes leaves in sorted-key order
+        result = _pure_tree_unflatten(td, [20, 30, 40])
+        assert result == {"z": 40, "a": 20, "m": 30}
+
+
+class TestTreeMapCornerCases:
+    """Corner cases for tree_map."""
+
+    def test_map_two_none_arguments(self):
+        result = _pure_tree_map(lambda x, y: (x, y), None, None)
+        assert result is None
+
+    def test_map_two_all_scalar_arguments(self):
+        result = _pure_tree_map(lambda x, y: x + y, 3, 4)
+        assert result == 7
+
+    def test_nested_structure_mismatch_deep(self):
+        """Mismatch at a deeply nested level should be detected."""
+        t1 = {"a": {"b": [1, 2]}}
+        t2 = {"a": {"b": [1, 2, 3]}}  # deeper mismatch
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: x + y, t1, t2)
+
+    def test_nested_type_mismatch(self):
+        """Type mismatch at a nested level."""
+        t1 = {"a": [1, 2]}
+        t2 = {"a": (1, 2)}  # list vs tuple at nested level
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: x + y, t1, t2)
+
+    def test_different_namedtuple_types_mismatch(self):
+        """Two different namedtuple types should not match."""
+        RGB = namedtuple("RGB", ["r", "g"])
+        # Point and RGB are different namedtuples with same field count
+        # _treedefs_compatible checks `a.typ is not b.typ` → mismatch
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: x + y, Point(1, 2), RGB(10, 20))
+
+    def test_different_arities_namedtuple_mismatch(self):
+        """namedtuples with different field counts should mismatch."""
+        RGB3 = namedtuple("RGB3", ["r", "g", "b"])
+        # Point has 2 fields, RGB3 has 3 → length mismatch
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(lambda x, y: x + y, Point(1, 2), RGB3(10, 20, 30))
+
+    def test_map_over_dict_with_empty_list_value(self):
+        tree = {"a": [], "b": [1, 2]}
+        result = _pure_tree_map(lambda x: x * 2, tree)
+        assert result == {"a": [], "b": [2, 4]}
+
+    def test_map_preserves_empty_containers(self):
+        for tree in [[], (), {}, None]:
+            result = _pure_tree_map(lambda x: x, tree)
+            assert result == tree
+
+    def test_map_with_dict_same_keys_different_insertion_order(self):
+        t1 = {"b": 2, "a": 1}
+        t2 = {"a": 10, "b": 20}
+        result = _pure_tree_map(lambda x, y: x + y, t1, t2)
+        assert result == {"b": 22, "a": 11}
+
+
+class TestJAXComparisonTreeMap:
+    """Directly compare tree_map behaviour with JAX.
+    These tests are skipped if JAX is not available."""
+
+    @pytest.fixture(autouse=True)
+    def _require_jax(self):
+        pytest.importorskip("jax")
+
+    def test_tree_map_basic_matches_jax(self):
+        from jax import tree_util
+
+        tree = {"a": [1, 2], "b": 3}
+        py_result = _pure_tree_map(lambda x: x * 2, tree)
+        jax_result = tree_util.tree_map(lambda x: x * 2, tree)
+        assert py_result == jax_result
+
+    def test_tree_map_two_args_matches_jax(self):
+        from jax import tree_util
+
+        t1 = {"a": [1, 2], "b": [3]}
+        t2 = {"a": [10, 20], "b": [30]}
+        py_result = _pure_tree_map(lambda x, y: x + y, t1, t2)
+        jax_result = tree_util.tree_map(lambda x, y: x + y, t1, t2)
+        assert py_result == jax_result
+
+    def test_tree_map_over_none_matches_jax(self):
+        from jax import tree_util
+
+        py_result = _pure_tree_map(lambda x: x + 1, None)
+        jax_result = tree_util.tree_map(lambda x: x + 1, None)
+        assert py_result == jax_result
+
+    def test_tree_map_rejects_mismatch_like_jax(self):
+        from jax import tree_util
+
+        # scalar broadcast should fail for both
+        with pytest.raises(ValueError):
+            tree_util.tree_map(lambda x, y: (x, y), {"a": [1, 2]}, 9)
+        with pytest.raises(ValueError):
+            _pure_tree_map(lambda x, y: (x, y), {"a": [1, 2]}, 9)
+
+    def test_tree_map_rejects_none_vs_scalar_like_jax(self):
+        from jax import tree_util
+
+        with pytest.raises((ValueError, TypeError)):
+            tree_util.tree_map(lambda x, y: (x, y), None, 5)
+        with pytest.raises(ValueError):
+            _pure_tree_map(lambda x, y: (x, y), None, 5)
+
+
+class TestJAXComparisonEmptyStructures:
+    """Compare empty structure handling with JAX."""
+
+    @pytest.fixture(autouse=True)
+    def _require_jax(self):
+        pytest.importorskip("jax")
+
+    def test_empty_list_matches_jax(self):
+        from jax import tree_util
+
+        jax_leaves, _ = tree_util.tree_flatten([])
+        pure_leaves, _ = _pure_tree_flatten([])
+        assert jax_leaves == pure_leaves == []
+
+    def test_empty_dict_matches_jax(self):
+        from jax import tree_util
+
+        jax_leaves, _ = tree_util.tree_flatten({})
+        pure_leaves, _ = _pure_tree_flatten({})
+        assert jax_leaves == pure_leaves == []
+
+    def test_roundtrip_empty_list(self):
+        from jax import tree_util
+
+        jax_leaves, jax_td = tree_util.tree_flatten([])
+        pure_leaves, pure_td = _pure_tree_flatten([])
+        assert tree_util.tree_unflatten(jax_td, jax_leaves) == _pure_tree_unflatten(
+            pure_td, pure_leaves
+        )
+
+
+# ---------------------------------------------------------------------------
+# JAX comparison tests (requires jax)
+# ---------------------------------------------------------------------------
+
+
+class TestJAXComparison:
+    """Directly compare behaviour with JAX ``tree_util``.
+    These tests are skipped if JAX is not available."""
+
+    @pytest.fixture(autouse=True)
+    def _require_jax(self):
+        pytest.importorskip("jax")
+
+    def test_flatten_dict_key_order_matches_jax(self):
+        from jax import tree_util
+
+        tree = {"b": 2, "a": 1}
+        jax_leaves, _ = tree_util.tree_flatten(tree)
+        pure_leaves, _ = _pure_tree_flatten(tree)
+        assert jax_leaves == pure_leaves
+
+    def test_flatten_none_matches_jax(self):
+        from jax import tree_util
+
+        jax_leaves, _ = tree_util.tree_flatten(None)
+        pure_leaves, _ = _pure_tree_flatten(None)
+        assert jax_leaves == pure_leaves == []
+
+    def test_unflatten_extra_leaves_matches_jax(self):
+        from jax import tree_util
+
+        _, jax_td = tree_util.tree_flatten({"a": 1})
+        _, pure_td = _pure_tree_flatten({"a": 1})
+
+        with pytest.raises(ValueError):
+            tree_util.tree_unflatten(jax_td, [10, 11])
+        with pytest.raises(ValueError):
+            _pure_tree_unflatten(pure_td, [10, 11])
+
+    def test_unflatten_too_few_leaves_matches_jax(self):
+        from jax import tree_util
+
+        _, jax_td = tree_util.tree_flatten({"a": 1, "b": 2})
+        _, pure_td = _pure_tree_flatten({"a": 1, "b": 2})
+
+        with pytest.raises(ValueError):
+            tree_util.tree_unflatten(jax_td, [10])
+        with pytest.raises(ValueError):
+            _pure_tree_unflatten(pure_td, [10])
+
+    def test_roundtrip_nested_matches_jax(self):
+        from jax import tree_util
+
+        tree = {"a": [1, (2, 3)], "b": {"c": 4}}
+        jax_leaves, jax_td = tree_util.tree_flatten(tree)
+        pure_leaves, pure_td = _pure_tree_flatten(tree)
+        assert jax_leaves == pure_leaves
+        assert tree_util.tree_unflatten(jax_td, jax_leaves) == _pure_tree_unflatten(
+            pure_td, pure_leaves
+        )
+
+    def test_flatten_nested_with_none_matches_jax(self):
+        from jax import tree_util
+
+        tree = {"a": None, "b": [None, 1], "c": 3}
+        jax_leaves, _ = tree_util.tree_flatten(tree)
+        pure_leaves, _ = _pure_tree_flatten(tree)
+        assert jax_leaves == pure_leaves

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -317,7 +317,7 @@ class TestUnflattenNested:
 
 
 class TestUnflattenLeafCountValidation:
-    """Validate leaf count on unflatten (JAX raises ValueError)."""
+    """Validate leaf count on unflatten."""
 
     def test_extra_leaves_raises_valueerror(self):
         _, td = _pure_tree_flatten({"a": 1})
@@ -409,7 +409,7 @@ class TestTreeMapMultiArg:
 
 
 class TestTreeMapStructureMismatch:
-    """JAX raises ValueError on structure mismatch."""
+    """Reject structure mismatches with ValueError."""
 
     def test_scalar_broadcast_is_rejected(self):
         with pytest.raises(ValueError, match="structure mismatch"):
@@ -549,23 +549,46 @@ class TestFlattenCornerCases:
         assert leaves == [fs]
         assert td.typ is _LEAF
 
-    def test_dict_subclass_is_container(self):
+    def test_dict_subclass_is_leaf(self):
         class MyDict(dict):
             pass
 
         tree = MyDict({"a": 1})
         leaves, td = _pure_tree_flatten(tree)
-        assert leaves == [1]
+        assert leaves == [tree]
+        assert td.typ is _LEAF
         assert td.num_leaves == 1
 
-    def test_list_subclass_is_container(self):
+    def test_list_subclass_is_leaf(self):
         class MyList(list):
             pass
 
         tree = MyList([1, 2])
         leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [tree]
+        assert td.typ is _LEAF
+        assert td.num_leaves == 1
+
+    def test_tuple_subclass_is_leaf(self):
+        class MyTuple(tuple):
+            pass
+
+        tree = MyTuple((1, 2))
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [tree]
+        assert td.typ is _LEAF
+        assert td.num_leaves == 1
+
+    def test_namedtuple_subclass_is_container(self):
+        class SubPoint(Point):
+            pass
+
+        tree = SubPoint(1, 2)
+        leaves, td = _pure_tree_flatten(tree)
         assert leaves == [1, 2]
-        assert td.num_leaves == 2
+        result = _pure_tree_unflatten(td, leaves)
+        assert type(result) is SubPoint
+        assert result == SubPoint(1, 2)
 
 
 class TestUnflattenCornerCases:
@@ -663,8 +686,13 @@ class TestTreeMapCornerCases:
             _pure_tree_map(boom, {"a": 1})
 
 
-class TestJAXComparisonTreeMap:
-    """Directly compare tree_map behaviour with JAX."""
+# ---------------------------------------------------------------------------
+# JAX cross-validation
+# ---------------------------------------------------------------------------
+
+
+class TestJAXComparison:
+    """Directly compare behaviour with JAX ``tree_util``."""
 
     def test_tree_map_basic_matches_jax(self):
         tree = {"a": [1, 2], "b": 3}
@@ -696,10 +724,6 @@ class TestJAXComparisonTreeMap:
         with pytest.raises(ValueError):
             _pure_tree_map(lambda x, y: (x, y), None, 99)
 
-
-class TestJAXComparisonEmptyStructures:
-    """Compare empty structure handling with JAX."""
-
     def test_empty_list_matches_jax(self):
         jax_leaves, _ = tree_util.tree_flatten([])
         pure_leaves, _ = _pure_tree_flatten([])
@@ -716,15 +740,6 @@ class TestJAXComparisonEmptyStructures:
         assert tree_util.tree_unflatten(jax_td, jax_leaves) == _pure_tree_unflatten(
             pure_td, pure_leaves
         )
-
-
-# ---------------------------------------------------------------------------
-# JAX comparison tests
-# ---------------------------------------------------------------------------
-
-
-class TestJAXComparison:
-    """Directly compare behaviour with JAX ``tree_util``."""
 
     def test_flatten_dict_key_order_matches_jax(self):
         tree = {"b": 2, "a": 1}

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -20,10 +20,7 @@ from collections import namedtuple
 import numpy as np
 import pytest
 
-try:
-    from jax import tree_util
-except ImportError:
-    tree_util = None  # type: ignore[assignment]
+from jax import tree_util
 
 thisfile = os.path.abspath(__file__)
 modulepath = os.path.dirname(os.path.dirname(thisfile))

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -13,18 +13,23 @@ semantics, covering:
   - complex nested structures
 """
 
-# pylint: disable=missing-class-docstring, missing-function-docstring
-
 import sys
 import os
 from collections import namedtuple
 
+import numpy as np
 import pytest
+
+try:
+    from jax import tree_util
+except ImportError:
+    tree_util = None  # type: ignore[assignment]
 
 thisfile = os.path.abspath(__file__)
 modulepath = os.path.dirname(os.path.dirname(thisfile))
 sys.path.insert(0, modulepath)
 
+import tensorcircuit as tc
 from tensorcircuit.backends.abstract_backend import (
     _pure_tree_flatten,
     _pure_tree_map,
@@ -294,11 +299,6 @@ class TestTreeMapBasic:
         result = _pure_tree_map(lambda x: x * 3, {"a": 1, "b": 2})
         assert result == {"a": 3, "b": 6}
 
-    def test_map_over_none(self):
-        # None is an empty pytree; map over it returns None
-        result = _pure_tree_map(lambda x: x + 1, None)
-        assert result is None
-
     def test_map_over_nested(self):
         tree = {"a": [1, 2], "b": (3,)}
         result = _pure_tree_map(lambda x: x + 10, tree)
@@ -368,27 +368,6 @@ class TestTreeMapNoArgs:
             _pure_tree_map(lambda: 42)
 
 
-class TestTreeMapDifferentTypes:
-    """Verify that container types are preserved."""
-
-    def test_tuple_preserved(self):
-        result = _pure_tree_map(lambda x: x + 1, (1, 2, 3))
-        assert isinstance(result, tuple)
-
-    def test_namedtuple_preserved(self):
-        result = _pure_tree_map(lambda x: x * 2, Point(3, 4))
-        assert isinstance(result, Point)
-        assert result == Point(6, 8)
-
-    def test_list_preserved(self):
-        result = _pure_tree_map(lambda x: x + 1, [1])
-        assert isinstance(result, list)
-
-    def test_dict_preserved(self):
-        result = _pure_tree_map(lambda x: x, {"k": 1})
-        assert isinstance(result, dict)
-
-
 # ---------------------------------------------------------------------------
 # Integration / round-trip with backend API
 # ---------------------------------------------------------------------------
@@ -397,28 +376,18 @@ class TestTreeMapDifferentTypes:
 class TestBackendIntegration:
     """Smoke tests through the ``tc.backend`` public API."""
 
-    def test_flatten_dict_key_order_via_backend(self):
-        import tensorcircuit as tc
-
-        tc.set_backend("numpy")
+    def test_flatten_dict_key_order_via_backend(self, npb):
         tree = {"b": 2, "a": 1}
         leaves, _ = tc.backend.tree_flatten(tree)
         assert leaves == [1, 2]
 
-    def test_roundtrip_via_backend(self):
-        import tensorcircuit as tc
-
-        tc.set_backend("numpy")
+    def test_roundtrip_via_backend(self, npb):
         tree = {"a": [1, 2], "b": (3, 4)}
         leaves, td = tc.backend.tree_flatten(tree)
         result = tc.backend.tree_unflatten(td, leaves)
         assert result == tree
 
-    def test_tree_map_via_backend(self):
-        import numpy as np
-        import tensorcircuit as tc
-
-        tc.set_backend("numpy")
+    def test_tree_map_via_backend(self, npb):
         tree = {"a": np.ones([2]), "b": np.zeros([3])}
         result = tc.backend.tree_map(lambda x: x + 1, tree)
         np.testing.assert_allclose(result["a"], 2 * np.ones([2]))
@@ -494,6 +463,41 @@ class TestFlattenCornerCases:
         leaves, _ = _pure_tree_flatten(tree)
         assert leaves == [1, "hello", 3.14, True]
 
+    def test_dict_with_integer_keys(self):
+        """Integer dict keys should be sorted numerically."""
+        tree = {2: "b", 1: "a", 3: "c"}
+        leaves, _ = _pure_tree_flatten(tree)
+        assert leaves == ["a", "b", "c"]
+
+    def test_frozenset_is_leaf(self):
+        """frozenset is not a supported container; it should be a leaf."""
+        fs = frozenset([1, 2, 3])
+        leaves, td = _pure_tree_flatten(fs)
+        assert leaves == [fs]
+        assert td.typ is _LEAF
+
+    def test_dict_subclass_is_container(self):
+        """Custom dict subclass is treated as a container (via isinstance)."""
+
+        class MyDict(dict):
+            pass
+
+        tree = MyDict({"a": 1})
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [1]
+        assert td.num_leaves == 1
+
+    def test_list_subclass_is_container(self):
+        """Custom list subclass is treated as a container (via isinstance)."""
+
+        class MyList(list):
+            pass
+
+        tree = MyList([1, 2])
+        leaves, td = _pure_tree_flatten(tree)
+        assert leaves == [1, 2]
+        assert td.num_leaves == 2
+
 
 class TestUnflattenCornerCases:
     """Corner cases for unflatten."""
@@ -506,18 +510,12 @@ class TestUnflattenCornerCases:
         assert r1 == {"a": 10, "b": 20}
         assert r2 == {"a": 30, "b": 40}
 
-    def test_unflatten_none_with_extra_leaves_raises(self):
-        _, td = _pure_tree_flatten(None)
-        with pytest.raises(ValueError, match="Too many leaves"):
-            _pure_tree_unflatten(td, [1])
-
-    def test_unflatten_empty_list_with_extra_leaves_raises(self):
-        _, td = _pure_tree_flatten([])
-        with pytest.raises(ValueError):
-            _pure_tree_unflatten(td, [1])
-
-    def test_unflatten_empty_dict_with_extra_leaves_raises(self):
-        _, td = _pure_tree_flatten({})
+    @pytest.mark.parametrize(
+        "tree", [None, [], {}], ids=["none", "empty_list", "empty_dict"]
+    )
+    def test_unflatten_empty_with_extra_leaves_raises(self, tree):
+        """0-leaf structures should reject any non-empty leaf list."""
+        _, td = _pure_tree_flatten(tree)
         with pytest.raises(ValueError):
             _pure_tree_unflatten(td, [1])
 
@@ -589,11 +587,26 @@ class TestTreeMapCornerCases:
             result = _pure_tree_map(lambda x: x, tree)
             assert result == tree
 
+    def test_map_preserves_namedtuple_type(self):
+        """namedtuple type must be preserved (not demoted to plain tuple)."""
+        result = _pure_tree_map(lambda x: x * 2, Point(3, 4))
+        assert isinstance(result, Point)
+        assert result == Point(6, 8)
+
     def test_map_with_dict_same_keys_different_insertion_order(self):
         t1 = {"b": 2, "a": 1}
         t2 = {"a": 10, "b": 20}
         result = _pure_tree_map(lambda x, y: x + y, t1, t2)
         assert result == {"b": 22, "a": 11}
+
+    def test_map_propagates_leaf_exception(self):
+        """Exception raised by f should propagate with context."""
+
+        def boom(x):
+            raise RuntimeError("leaf error")
+
+        with pytest.raises(RuntimeError, match="leaf error"):
+            _pure_tree_map(boom, {"a": 1})
 
 
 class TestJAXComparisonTreeMap:
@@ -605,16 +618,12 @@ class TestJAXComparisonTreeMap:
         pytest.importorskip("jax")
 
     def test_tree_map_basic_matches_jax(self):
-        from jax import tree_util
-
         tree = {"a": [1, 2], "b": 3}
         py_result = _pure_tree_map(lambda x: x * 2, tree)
         jax_result = tree_util.tree_map(lambda x: x * 2, tree)
         assert py_result == jax_result
 
     def test_tree_map_two_args_matches_jax(self):
-        from jax import tree_util
-
         t1 = {"a": [1, 2], "b": [3]}
         t2 = {"a": [10, 20], "b": [30]}
         py_result = _pure_tree_map(lambda x, y: x + y, t1, t2)
@@ -622,28 +631,22 @@ class TestJAXComparisonTreeMap:
         assert py_result == jax_result
 
     def test_tree_map_over_none_matches_jax(self):
-        from jax import tree_util
-
         py_result = _pure_tree_map(lambda x: x + 1, None)
         jax_result = tree_util.tree_map(lambda x: x + 1, None)
         assert py_result == jax_result
 
     def test_tree_map_rejects_mismatch_like_jax(self):
-        from jax import tree_util
-
-        # scalar broadcast should fail for both
+        # dict vs scalar: different input from the pure test
         with pytest.raises(ValueError):
-            tree_util.tree_map(lambda x, y: (x, y), {"a": [1, 2]}, 9)
+            tree_util.tree_map(lambda x, y: (x, y), {"x": [3, 4]}, "bad")
         with pytest.raises(ValueError):
-            _pure_tree_map(lambda x, y: (x, y), {"a": [1, 2]}, 9)
+            _pure_tree_map(lambda x, y: (x, y), {"x": [3, 4]}, "bad")
 
     def test_tree_map_rejects_none_vs_scalar_like_jax(self):
-        from jax import tree_util
-
         with pytest.raises((ValueError, TypeError)):
-            tree_util.tree_map(lambda x, y: (x, y), None, 5)
+            tree_util.tree_map(lambda x, y: (x, y), None, 99)
         with pytest.raises(ValueError):
-            _pure_tree_map(lambda x, y: (x, y), None, 5)
+            _pure_tree_map(lambda x, y: (x, y), None, 99)
 
 
 class TestJAXComparisonEmptyStructures:
@@ -654,22 +657,16 @@ class TestJAXComparisonEmptyStructures:
         pytest.importorskip("jax")
 
     def test_empty_list_matches_jax(self):
-        from jax import tree_util
-
         jax_leaves, _ = tree_util.tree_flatten([])
         pure_leaves, _ = _pure_tree_flatten([])
         assert jax_leaves == pure_leaves == []
 
     def test_empty_dict_matches_jax(self):
-        from jax import tree_util
-
         jax_leaves, _ = tree_util.tree_flatten({})
         pure_leaves, _ = _pure_tree_flatten({})
         assert jax_leaves == pure_leaves == []
 
     def test_roundtrip_empty_list(self):
-        from jax import tree_util
-
         jax_leaves, jax_td = tree_util.tree_flatten([])
         pure_leaves, pure_td = _pure_tree_flatten([])
         assert tree_util.tree_unflatten(jax_td, jax_leaves) == _pure_tree_unflatten(
@@ -691,23 +688,17 @@ class TestJAXComparison:
         pytest.importorskip("jax")
 
     def test_flatten_dict_key_order_matches_jax(self):
-        from jax import tree_util
-
         tree = {"b": 2, "a": 1}
         jax_leaves, _ = tree_util.tree_flatten(tree)
         pure_leaves, _ = _pure_tree_flatten(tree)
         assert jax_leaves == pure_leaves
 
     def test_flatten_none_matches_jax(self):
-        from jax import tree_util
-
         jax_leaves, _ = tree_util.tree_flatten(None)
         pure_leaves, _ = _pure_tree_flatten(None)
         assert jax_leaves == pure_leaves == []
 
     def test_unflatten_extra_leaves_matches_jax(self):
-        from jax import tree_util
-
         _, jax_td = tree_util.tree_flatten({"a": 1})
         _, pure_td = _pure_tree_flatten({"a": 1})
 
@@ -717,8 +708,6 @@ class TestJAXComparison:
             _pure_tree_unflatten(pure_td, [10, 11])
 
     def test_unflatten_too_few_leaves_matches_jax(self):
-        from jax import tree_util
-
         _, jax_td = tree_util.tree_flatten({"a": 1, "b": 2})
         _, pure_td = _pure_tree_flatten({"a": 1, "b": 2})
 
@@ -728,8 +717,6 @@ class TestJAXComparison:
             _pure_tree_unflatten(pure_td, [10])
 
     def test_roundtrip_nested_matches_jax(self):
-        from jax import tree_util
-
         tree = {"a": [1, (2, 3)], "b": {"c": 4}}
         jax_leaves, jax_td = tree_util.tree_flatten(tree)
         pure_leaves, pure_td = _pure_tree_flatten(tree)
@@ -739,8 +726,6 @@ class TestJAXComparison:
         )
 
     def test_flatten_nested_with_none_matches_jax(self):
-        from jax import tree_util
-
         tree = {"a": None, "b": [None, 1], "c": 3}
         jax_leaves, _ = tree_util.tree_flatten(tree)
         pure_leaves, _ = _pure_tree_flatten(tree)

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -123,14 +123,14 @@ class TestFlattenDictKeyOrder:
 class TestFlattenOrderedDict:
     """OrderedDict preserves insertion order (not sorted like dict)."""
 
-    def test_orderedict_preserves_insertion_order(self):
+    def test_ordereddict_preserves_insertion_order(self):
         od = OrderedDict([("c", 3), ("a", 1), ("b", 2)])
         leaves, td = _pure_tree_flatten(od)
         # Insertion order, not sorted
         assert leaves == [3, 1, 2]
         assert td.sorted_keys == ("c", "a", "b")
 
-    def test_orderedict_type_recorded(self):
+    def test_ordereddict_type_recorded(self):
         od = OrderedDict([("a", 1)])
         _, td = _pure_tree_flatten(od)
         assert td.typ is OrderedDict
@@ -369,7 +369,7 @@ class TestTreeMapBasic:
         result = _pure_tree_map(lambda x: x + 10, tree)
         assert result == {"a": [11, 12], "b": (13,)}
 
-    def test_map_preserves_orderedict_type(self):
+    def test_map_preserves_ordereddict_type(self):
         od = OrderedDict([("c", 1), ("a", 2)])
         result = _pure_tree_map(lambda x: x * 10, od)
         assert isinstance(result, OrderedDict)
@@ -434,6 +434,14 @@ class TestTreeMapStructureMismatch:
     def test_type_mismatch_dict_vs_list(self):
         with pytest.raises(ValueError, match="structure mismatch"):
             _pure_tree_map(lambda x, y: (x, y), {"a": 1}, [1])
+
+    def test_defaultdict_factory_mismatch(self):
+        with pytest.raises(ValueError, match="structure mismatch"):
+            _pure_tree_map(
+                lambda x, y: (x, y),
+                defaultdict(int, {"a": 1}),
+                defaultdict(list, {"a": 2}),
+            )
 
 
 class TestTreeMapNoArgs:

--- a/tests/test_pure_pytree.py
+++ b/tests/test_pure_pytree.py
@@ -607,12 +607,7 @@ class TestTreeMapCornerCases:
 
 
 class TestJAXComparisonTreeMap:
-    """Directly compare tree_map behaviour with JAX.
-    These tests are skipped if JAX is not available."""
-
-    @pytest.fixture(autouse=True)
-    def _require_jax(self):
-        pytest.importorskip("jax")
+    """Directly compare tree_map behaviour with JAX."""
 
     def test_tree_map_basic_matches_jax(self):
         tree = {"a": [1, 2], "b": 3}
@@ -649,10 +644,6 @@ class TestJAXComparisonTreeMap:
 class TestJAXComparisonEmptyStructures:
     """Compare empty structure handling with JAX."""
 
-    @pytest.fixture(autouse=True)
-    def _require_jax(self):
-        pytest.importorskip("jax")
-
     def test_empty_list_matches_jax(self):
         jax_leaves, _ = tree_util.tree_flatten([])
         pure_leaves, _ = _pure_tree_flatten([])
@@ -677,12 +668,7 @@ class TestJAXComparisonEmptyStructures:
 
 
 class TestJAXComparison:
-    """Directly compare behaviour with JAX ``tree_util``.
-    These tests are skipped if JAX is not available."""
-
-    @pytest.fixture(autouse=True)
-    def _require_jax(self):
-        pytest.importorskip("jax")
+    """Directly compare behaviour with JAX ``tree_util``."""
 
     def test_flatten_dict_key_order_matches_jax(self):
         tree = {"b": 2, "a": 1}


### PR DESCRIPTION
Replace hardcoded np.complex128/complex64 with cons.npdtype/dtypestr in:
- gates.py: cnot_gate, cmz_gate (5 instances)
- pauliprop.py: Pauli matrices and backend API calls (8 instances) Also fix _aggregate_and_truncate: mask non-boundary entries after top_k
- translation.py: qir2qiskit theta cast (1 instance)
- applications/vqes.py, vags.py, utils.py: TF/NP hardcoded types (14 instances)

Fix numpy_backend.py:
- expm(): auto-upcast to safe precision via np.result_type, then cast back
- cast(): wrap Python scalars with np.asarray() before .astype()

Add pure Python tree utils in abstract_backend.py:
- _pure_tree_flatten, _pure_tree_unflatten, _pure_tree_map
- tree_map/tree_flatten/tree_unflatten now fallback to pure Python

Fix Intel OpenMP DLL conflict in tests/conftest.py:
- Set KMP_DUPLICATE_LIB_OK=TRUE to allow PyTorch + scipy coexistence